### PR TITLE
Feature/12 non integer values

### DIFF
--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -1643,6 +1643,12 @@ class EventList(Transformable):
         """
         # TODO: optimization: refactor calls of iterSlice() to pass slices?
         if not isinstance(start, slice):
+            if start is not None:
+                start = round(start)
+            if end is not None:
+                end = round(end)
+            if step is not None:
+                step = round(step)
             start = slice(start, end, step)
         start, end, step = start.indices(len(self))
 
@@ -1731,6 +1737,12 @@ class EventList(Transformable):
         """
         # TODO: optimization: refactor calls of iterJitterySlice() to pass slices?
         if not isinstance(start, slice):
+            if start is not None:
+                start = round(start)
+            if end is not None:
+                end = round(end)
+            if step is not None:
+                step = round(step)
             start = slice(start, end, step)
         start, end, step = start.indices(len(self))
         
@@ -2431,7 +2443,13 @@ class EventList(Transformable):
             _self.removeMean = _self.allowMeanRemoval and removeMean
         if meanSpan is not None:
             _self.rollingMeanSpan = meanSpan
-        
+
+        if start is not None:
+            start = round(start)
+        if stop is not None:
+            stop = round(stop)
+        if step is not None:
+            step = round(step)
         start, stop, step = slice(start, stop, step).indices(len(self))
 
         totalLines = len(range(start, stop, step))

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2772,6 +2772,12 @@ class EventArray(EventList):
         """
         # TODO: optimization: refactor calls of iterSlice() to pass slices?
         if not isinstance(start, slice):
+            if start is not None:
+                start = round(start)
+            if end is not None:
+                end = round(end)
+            if step is not None:
+                step = round(step)
             start = slice(start, end, step)
         start, end, step = start.indices(len(self))
 
@@ -2863,6 +2869,12 @@ class EventArray(EventList):
         """
         # TODO: optimization: refactor calls of iterJitterySlice() to pass slices?
         if not isinstance(start, slice):
+            if start is not None:
+                start = round(start)
+            if end is not None:
+                end = round(end)
+            if step is not None:
+                step = round(step)
             start = slice(start, end, step)
         start, end, step = start.indices(len(self))
 

--- a/idelib/parsers.py
+++ b/idelib/parsers.py
@@ -523,6 +523,12 @@ class BaseDataBlock(object):
         """
         # SimpleChannelDataBlock payloads contain header info; skip it.
         data = self.payload
+        if start is not None:
+            start = round(start)
+        if end is not None:
+            end = round(end)
+        if step is not None:
+            step = round(step)
         start, end, step = slice(start, end, step).indices(self.payloadSize // parser.size)
 
         start = (start*parser.size)
@@ -663,6 +669,12 @@ class SimpleChannelDataBlock(BaseDataBlock):
         """
         # SimpleChannelDataBlock payloads contain header info; skip it.
         data = self.payload
+        if start is not None:
+            start = round(start)
+        if end is not None:
+            end = round(end)
+        if step is not None:
+            step = round(step)
         start, end, step = slice(start, end, step).indices(
             (self.payloadSize-self.headerSize) // parser.size
         )
@@ -672,10 +684,10 @@ class SimpleChannelDataBlock(BaseDataBlock):
         
         parser_unpack_from = parser.unpack_from
         if subchannel is not None:
-            for i in range(start,end,parser.size*step):
+            for i in range(start, end, parser.size*step):
                 yield parser_unpack_from(data, i)[subchannel]
         else:
-            for i in range(start,end,parser.size*step):
+            for i in range(start, end, parser.size*step):
                 yield parser_unpack_from(data, i)
 
 

--- a/testing/test_new_dataset.py
+++ b/testing/test_new_dataset.py
@@ -130,6 +130,7 @@ class TestEventArray:
              (0, 100, 1, np.arange(100, dtype=np.float64)[np.newaxis, :]),
              (0, 99.9, 1, np.arange(100, dtype=np.float64)[np.newaxis, :]),
              (0.1, 99.9, 1, np.arange(100, dtype=np.float64)[np.newaxis, :]),
+             (np.float(0.1), np.float(99.9), 1, np.arange(100, dtype=np.float64)[np.newaxis, :]),
              ]
             )
     def test_array_values(self, channel_8_eventarray, start, end, step, expected):
@@ -142,6 +143,7 @@ class TestEventArray:
              (0, 100, 1, np.arange(100, dtype=np.float64)),
              (0, 99.9, 1, np.arange(100, dtype=np.float64)),
              (0.1, 99.9, 1, np.arange(100, dtype=np.float64)),
+             (np.float(0.1), np.float(99.9), 1, np.arange(100, dtype=np.float64)),
              ]
             )
     def test_array_jittery_values(self, channel_8_eventarray, start, end, step, expected):

--- a/testing/test_new_dataset.py
+++ b/testing/test_new_dataset.py
@@ -124,7 +124,26 @@ class TestEventArray:
     def test_init(self, new_event_array, channel_8_eventarray):
         assert new_event_array == channel_8_eventarray
 
-    def test_array_values(self, channel_8_eventarray):
-        values = channel_8_eventarray.arrayValues(start=None, end=None, step=None, subchannels=(0,))
-        np.testing.assert_equal(values,
-                                np.arange(1000, dtype=np.float64)[np.newaxis, :])
+    @pytest.mark.parametrize(
+            'start, end, step, expected',
+            [(None, None, None, np.arange(1000, dtype=np.float64)[np.newaxis, :]),
+             (0, 100, 1, np.arange(100, dtype=np.float64)[np.newaxis, :]),
+             (0, 99.9, 1, np.arange(100, dtype=np.float64)[np.newaxis, :]),
+             (0.1, 99.9, 1, np.arange(100, dtype=np.float64)[np.newaxis, :]),
+             ]
+            )
+    def test_array_values(self, channel_8_eventarray, start, end, step, expected):
+        values = channel_8_eventarray.arrayValues(start=start, end=end, step=step, subchannels=(0,))
+        np.testing.assert_equal(values, expected)
+
+    @pytest.mark.parametrize(
+            'start, end, step, expected',
+            [(None, None, None, np.arange(1000, dtype=np.float64)),
+             (0, 100, 1, np.arange(100, dtype=np.float64)),
+             (0, 99.9, 1, np.arange(100, dtype=np.float64)),
+             (0.1, 99.9, 1, np.arange(100, dtype=np.float64)),
+             ]
+            )
+    def test_array_jittery_values(self, channel_8_eventarray, start, end, step, expected):
+        values = channel_8_eventarray.arrayJitterySlice(start=start, end=end, step=step)[1, :]
+        np.testing.assert_equal(values, expected)


### PR DESCRIPTION
This fixes an issue in dataset.EventArray._blockSlice and dataset.EventArray._blockSlice.  Slice objects defined with floats raise a type error when calling the indices method on it, and it's pretty easy to end up passing one in

fixes #12 