### PR TITLE
Feature/22 23 lab3 changes

### DIFF
--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2506,14 +2506,14 @@ class EventArray(EventList):
         dynamically read from the underlying EBML file. 
     """
 
-    # def __init__(self, parentChannel, session=None, parentList=None):
-    #     """ Constructor. This should almost always be done indirectly via
-    #         the `getSession()` method of `Channel` and `SubChannel` objects.
-    #     """
-    #     super(EventArray, self).__init__(parentChannel, session, parentList)
-    #
-    #     self._blockIndicesArray = np.array([], dtype=np.float64)
-    #     self._blockTimesArray = np.array([], dtype=np.float64)
+    def __init__(self, parentChannel, session=None, parentList=None):
+        """ Constructor. This should almost always be done indirectly via
+            the `getSession()` method of `Channel` and `SubChannel` objects.
+        """
+        super(EventArray, self).__init__(parentChannel, session, parentList)
+
+        self._blockIndicesArray = np.array([], dtype=np.float64)
+        self._blockTimesArray = np.array([], dtype=np.float64)
 
     #===========================================================================
     # New utility methods
@@ -2598,7 +2598,7 @@ class EventArray(EventList):
     #         :keyword start: The first block index to search
     #         :keyword stop: The last block index to search
     #     """
-    #     # NOTE: This appears to be marginally slower than the original code.
+    #     # TODO: profile & determine if this change is beneficial
     #     if len(self._blockIndicesArray) != len(self._blockIndices):
     #         self._blockIndicesArray = np.array(self._blockIndices)
     #
@@ -2615,7 +2615,7 @@ class EventArray(EventList):
     #         :keyword start: The first block index to search
     #         :keyword stop: The last block index to search
     #     """
-    #     # NOTE: This appears to be marginally slower than the original code.
+    #     # TODO: profile & determine if this change is beneficial
     #     if len(self._blockTimesArray) != len(self._blockTimes):
     #         self._blockTimesArray = np.array(self._blockTimes)
     #

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2457,9 +2457,6 @@ class EventList(Transformable):
         totalSamples = totalLines * numChannels
         updateInt = int(totalLines * callbackInterval)
         
-        # Catch all or no exceptions
-        ex = None if raiseExceptions or noCallback else Exception
-        
         t0 = datetime.now()
         if headers:
             stream.write('"Time"%s%s\n' % 
@@ -2477,8 +2474,11 @@ class EventList(Transformable):
                         callback(num*numChannels, total=totalSamples)
             if callback is not None:
                 callback(done=True)
-        except ex as e:
-            callback(error=e)
+        except Exception as e:
+            if raiseExceptions:
+                raise
+            elif callback is not None:
+                callback(error=e)
 
         return num+1, datetime.now() - t0
 

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2590,39 +2590,39 @@ class EventArray(EventList):
     # Derived utility methods
     #===========================================================================
 
-    def _getBlockIndexWithIndex(self, idx, start=0, stop=None):
-        """ Get the index of a raw data block that contains the given event
-            index.
-
-            :param idx: The event index to find
-            :keyword start: The first block index to search
-            :keyword stop: The last block index to search
-        """
-        # TODO: profile & determine if this change is beneficial
-        if len(self._blockIndicesArray) != len(self._blockIndices):
-            self._blockIndicesArray = np.array(self._blockIndices)
-
-        idxOffset = max(start, 1)
-        return idxOffset-1 + np.searchsorted(
-            self._blockIndicesArray[idxOffset:stop], idx, side='right'
-        )
-
-
-    def _getBlockIndexWithTime(self, t, start=0, stop=None):
-        """ Get the index of a raw data block in which the given time occurs.
-
-            :param t: The time to find
-            :keyword start: The first block index to search
-            :keyword stop: The last block index to search
-        """
-        # TODO: profile & determine if this change is beneficial
-        if len(self._blockTimesArray) != len(self._blockTimes):
-            self._blockTimesArray = np.array(self._blockTimes)
-
-        idxOffset = max(start, 1)
-        return idxOffset-1 + np.searchsorted(
-            self._blockTimesArray[idxOffset:stop], t, side='right'
-        )
+    # def _getBlockIndexWithIndex(self, idx, start=0, stop=None):
+    #     """ Get the index of a raw data block that contains the given event
+    #         index.
+    #
+    #         :param idx: The event index to find
+    #         :keyword start: The first block index to search
+    #         :keyword stop: The last block index to search
+    #     """
+    #     # TODO: profile & determine if this change is beneficial
+    #     if len(self._blockIndicesArray) != len(self._blockIndices):
+    #         self._blockIndicesArray = np.array(self._blockIndices)
+    #
+    #     idxOffset = max(start, 1)
+    #     return idxOffset-1 + np.searchsorted(
+    #         self._blockIndicesArray[idxOffset:stop], idx, side='right'
+    #     )
+    #
+    #
+    # def _getBlockIndexWithTime(self, t, start=0, stop=None):
+    #     """ Get the index of a raw data block in which the given time occurs.
+    #
+    #         :param t: The time to find
+    #         :keyword start: The first block index to search
+    #         :keyword stop: The last block index to search
+    #     """
+    #     # TODO: profile & determine if this change is beneficial
+    #     if len(self._blockTimesArray) != len(self._blockTimes):
+    #         self._blockTimesArray = np.array(self._blockTimes)
+    #
+    #     idxOffset = max(start, 1)
+    #     return idxOffset-1 + np.searchsorted(
+    #         self._blockTimesArray[idxOffset:stop], t, side='right'
+    #     )
 
 
     def _getBlockRollingMean(self, blockIdx, force=False):
@@ -3112,7 +3112,7 @@ class EventArray(EventList):
     '''
 
     def arrayMinMeanMax(self, startTime=None, endTime=None, padding=0,
-                        times=True, display=False):
+                        times=True, display=False, iterator=iter):
         """ Get the minimum, mean, and maximum values for blocks within a
             specified interval.
 
@@ -3131,13 +3131,13 @@ class EventArray(EventList):
                 and max, respectively).
         """
 
-        return np.moveaxis([i for i in self.iterMinMeanMax(
+        return np.moveaxis([i for i in iterator(self.iterMinMeanMax(
             startTime, endTime, padding, times, display
-        )], 0, -1)
+        ))], 0, -1)
 
 
     def getMinMeanMax(self, startTime=None, endTime=None, padding=0,
-                      times=True, display=False):
+                      times=True, display=False, iterator=iter):
         """ Get the minimum, mean, and maximum values for blocks within a
             specified interval. (Currently an alias of `arrayMinMeanMax`.)
 
@@ -3156,11 +3156,11 @@ class EventArray(EventList):
                 and max, respectively).
         """
         return self.arrayMinMeanMax(startTime, endTime, padding, times,
-                                    display)
+                                    display, iterator)
 
 
     def getRangeMinMeanMax(self, startTime=None, endTime=None, subchannel=None,
-                           display=False):
+                           display=False, iterator=iter):
         """ Get the single minimum, mean, and maximum value for blocks within a
             specified interval. Note: Using this with a parent channel without
             specifying a subchannel number can produce meaningless data if the
@@ -3178,7 +3178,7 @@ class EventArray(EventList):
                 and max, respectively).
         """
         stats = self.arrayMinMeanMax(startTime, endTime, times=False,
-                                     display=display)
+                                     display=display, iterator=iterator)
 
         if stats.size == 0:
             return None
@@ -3196,7 +3196,7 @@ class EventArray(EventList):
             )
 
 
-    def getMax(self, startTime=None, endTime=None, display=False):
+    def getMax(self, startTime=None, endTime=None, display=False, iterator=iter):
         """ Get the event with the maximum value, optionally within a specified
             time range. For Channels, returns the maximum among all
             Subchannels.
@@ -3208,7 +3208,7 @@ class EventArray(EventList):
             :return: The event with the maximum value.
         """
         maxs = self.arrayMinMeanMax(startTime, endTime, times=False,
-                                    display=display)[2].max(axis=0)
+                                    display=display, iterator=iterator)[2].max(axis=0)
 
         blockIdx = maxs.argmax()  # TODO: is this bug-free? double-check
         sampleIdxRange = self._data[blockIdx].indexRange
@@ -3218,7 +3218,7 @@ class EventArray(EventList):
         return blockData[:, subIdx]
 
 
-    def getMin(self, startTime=None, endTime=None, display=False):
+    def getMin(self, startTime=None, endTime=None, display=False, iterator=iter):
         """ Get the event with the minimum value, optionally within a specified
             time range. For Channels, returns the minimum among all
             Subchannels.
@@ -3233,7 +3233,7 @@ class EventArray(EventList):
             self._computeMinMeanMax()
 
         mins = self.arrayMinMeanMax(startTime, endTime, times=False,
-                                    display=display)[0].min(axis=0)
+                                    display=display, iterator=iterator)[0].min(axis=0)
 
         blockIdx = mins.argmin()  # TODO: is this bug-free? double-check
         sampleIdxRange = self._data[blockIdx].indexRange
@@ -3487,7 +3487,7 @@ class WarningRange(object):
             return s
         
     
-    def getRange(self, start=None, end=None, sessionId=None):
+    def getRange(self, start=None, end=None, sessionId=None, iterator=iter):
         """ Retrieve the invalid periods within a given range of events.
             
             :return: A list of invalid periods' [start, end] times.
@@ -3512,7 +3512,7 @@ class WarningRange(object):
         if outOfRange:
             result = [[start,start]]
         
-        for event in source.iterRange(start, end):
+        for event in iter(source.iterRange(start, end)):
             t = event[0]
             if self.valid(event[1:]):
                 if outOfRange:

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2590,39 +2590,39 @@ class EventArray(EventList):
     # Derived utility methods
     #===========================================================================
 
-    # def _getBlockIndexWithIndex(self, idx, start=0, stop=None):
-    #     """ Get the index of a raw data block that contains the given event
-    #         index.
-    #
-    #         :param idx: The event index to find
-    #         :keyword start: The first block index to search
-    #         :keyword stop: The last block index to search
-    #     """
-    #     # TODO: profile & determine if this change is beneficial
-    #     if len(self._blockIndicesArray) != len(self._blockIndices):
-    #         self._blockIndicesArray = np.array(self._blockIndices)
-    #
-    #     idxOffset = max(start, 1)
-    #     return idxOffset-1 + np.searchsorted(
-    #         self._blockIndicesArray[idxOffset:stop], idx, side='right'
-    #     )
-    #
-    #
-    # def _getBlockIndexWithTime(self, t, start=0, stop=None):
-    #     """ Get the index of a raw data block in which the given time occurs.
-    #
-    #         :param t: The time to find
-    #         :keyword start: The first block index to search
-    #         :keyword stop: The last block index to search
-    #     """
-    #     # TODO: profile & determine if this change is beneficial
-    #     if len(self._blockTimesArray) != len(self._blockTimes):
-    #         self._blockTimesArray = np.array(self._blockTimes)
-    #
-    #     idxOffset = max(start, 1)
-    #     return idxOffset-1 + np.searchsorted(
-    #         self._blockTimesArray[idxOffset:stop], t, side='right'
-    #     )
+    def _getBlockIndexWithIndex(self, idx, start=0, stop=None):
+        """ Get the index of a raw data block that contains the given event
+            index.
+
+            :param idx: The event index to find
+            :keyword start: The first block index to search
+            :keyword stop: The last block index to search
+        """
+        # TODO: profile & determine if this change is beneficial
+        if len(self._blockIndicesArray) != len(self._blockIndices):
+            self._blockIndicesArray = np.array(self._blockIndices)
+
+        idxOffset = max(start, 1)
+        return idxOffset-1 + np.searchsorted(
+            self._blockIndicesArray[idxOffset:stop], idx, side='right'
+        )
+
+
+    def _getBlockIndexWithTime(self, t, start=0, stop=None):
+        """ Get the index of a raw data block in which the given time occurs.
+
+            :param t: The time to find
+            :keyword start: The first block index to search
+            :keyword stop: The last block index to search
+        """
+        # TODO: profile & determine if this change is beneficial
+        if len(self._blockTimesArray) != len(self._blockTimes):
+            self._blockTimesArray = np.array(self._blockTimes)
+
+        idxOffset = max(start, 1)
+        return idxOffset-1 + np.searchsorted(
+            self._blockTimesArray[idxOffset:stop], t, side='right'
+        )
 
 
     def _getBlockRollingMean(self, blockIdx, force=False):

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2506,14 +2506,14 @@ class EventArray(EventList):
         dynamically read from the underlying EBML file. 
     """
 
-    def __init__(self, parentChannel, session=None, parentList=None):
-        """ Constructor. This should almost always be done indirectly via
-            the `getSession()` method of `Channel` and `SubChannel` objects.
-        """
-        super(EventArray, self).__init__(parentChannel, session, parentList)
-
-        self._blockIndicesArray = np.array([], dtype=np.float64)
-        self._blockTimesArray = np.array([], dtype=np.float64)
+    # def __init__(self, parentChannel, session=None, parentList=None):
+    #     """ Constructor. This should almost always be done indirectly via
+    #         the `getSession()` method of `Channel` and `SubChannel` objects.
+    #     """
+    #     super(EventArray, self).__init__(parentChannel, session, parentList)
+    #
+    #     self._blockIndicesArray = np.array([], dtype=np.float64)
+    #     self._blockTimesArray = np.array([], dtype=np.float64)
 
     #===========================================================================
     # New utility methods
@@ -2598,7 +2598,7 @@ class EventArray(EventList):
     #         :keyword start: The first block index to search
     #         :keyword stop: The last block index to search
     #     """
-    #     # TODO: profile & determine if this change is beneficial
+    #     # NOTE: This appears to be marginally slower than the original code.
     #     if len(self._blockIndicesArray) != len(self._blockIndices):
     #         self._blockIndicesArray = np.array(self._blockIndices)
     #
@@ -2615,7 +2615,7 @@ class EventArray(EventList):
     #         :keyword start: The first block index to search
     #         :keyword stop: The last block index to search
     #     """
-    #     # TODO: profile & determine if this change is beneficial
+    #     # NOTE: This appears to be marginally slower than the original code.
     #     if len(self._blockTimesArray) != len(self._blockTimes):
     #         self._blockTimesArray = np.array(self._blockTimes)
     #

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -1128,7 +1128,6 @@ class EventList(Transformable):
         self._length = 0
         self.dataset = parentChannel.dataset
         self.hasSubchannels = not isinstance(self.parent, SubChannel)
-        self._firstTime = self._lastTime = None
         self._parentList = parentList
         self._childLists = []
         
@@ -1237,8 +1236,6 @@ class EventList(Transformable):
         newList = self.__class__(parent, self.session, self)
         newList._data = self._data
         newList._length = self._length
-        newList._firstTime = self._firstTime
-        newList._lastTime = self._lastTime
         newList.dataset = self.dataset
         newList.hasMinMeanMax = self.hasMinMeanMax
         newList.removeMean = self.removeMean
@@ -1272,10 +1269,6 @@ class EventList(Transformable):
         else:
             self.session.lastTime = max(self.session.lastTime, block.endTime)
 
-        if self._firstTime is None:
-            self._firstTime = block.startTime
-        self._lastTime = block.endTime
-        
         # Check that the block actually contains at least one sample.
         if block.numSamples < 1:
             # Ignore blocks with empty payload. Could occur in FW <17.
@@ -1330,21 +1323,23 @@ class EventList(Transformable):
             self.hasMinMeanMax = True
 #             self.hasMinMeanMax = False
 #             self.allowMeanRemoval = False
-        
-    
+
+    @property
+    def _firstTime(self):
+        return self._data[0].startTime if self._data else None
+
+    @property
+    def _lastTime(self):
+        return self._data[-1].endTime if self._data else None
+
     def getInterval(self):
         """ Get the first and last event times in the set.
         """
         if len(self._data) == 0:
             return None
-#         if self._firstTime is None:
-#             self._firstTime = self._data[0].startTime
-        if self.dataset.loading:
-            return self._firstTime, self._data[-1].endTime
-        if self._lastTime is None:
-            self._lastTime = self._data[-1].endTime
+
         return self._firstTime, self._lastTime
-    
+
 
     def _getBlockIndexRange(self, blockIdx):
         """ Get the first and last index of the subsamples within a block,

--- a/idelib/util.py
+++ b/idelib/util.py
@@ -16,18 +16,12 @@ import time
 
 from ebmlite import loadSchema
 
-# ==============================================================================
-# 
-# ==============================================================================
-
-mideSchema = loadSchema('mide_ide.xml')
-
 
 # ==============================================================================
 # 
 # ==============================================================================
 
-def verify(data, schema=mideSchema):
+def verify(data, schema=None):
     """ Basic sanity-check of data validity. If the data is bad an exception
         will be raised. The specific exception varies depending on the problem
         in the data.
@@ -35,6 +29,8 @@ def verify(data, schema=mideSchema):
         :keyword schema: The full module name of the EBML schema.
         :return: `True`. Any problems will raise exceptions.
     """
+    if schema is None:
+        schema = loadSchema('mide_ide.xml')
     return schema.verify(data)
 
 
@@ -81,6 +77,8 @@ def encode_attributes(data):
         data = list(data.items())
     
     result = []
+    elementType = None
+
     for d in data:
         if isinstance(d[1], (tuple, list)) and not isinstance(d[1], time.struct_time):
             k = d[0]
@@ -112,4 +110,5 @@ def build_attributes(data):
         `FloatAttribute`, etc.). The value element type will otherwise be 
         inferred.
     """
+    mideSchema = loadSchema('mide_ide.xml')
     return mideSchema['Attribute'].encode(encode_attributes(data))

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -1065,6 +1065,7 @@ class EventListTestCase(unittest.TestCase):
     def testGetInterval(self):
         """ Test the getInterval method. """
         fakeObject = GenericObject()
+        fakeObject.startTime = 3
         fakeObject.endTime = 1
         accel = self.dataset.channels[32].getSession()
         
@@ -1074,7 +1075,6 @@ class EventListTestCase(unittest.TestCase):
         
         # with mocked data
         accel._data = [fakeObject]
-        accel._firstTime = 3
         self.assertEqual(accel.getInterval(), (3, 1))
         self.assertEqual(accel._lastTime, 1)
         
@@ -1871,6 +1871,7 @@ class EventArrayTestCase(unittest.TestCase):
     def testGetInterval(self):
         """ Test the getInterval method. """
         fakeObject = GenericObject()
+        fakeObject.startTime = 3
         fakeObject.endTime = 1
         accel = self.dataset.channels[32].getSession()
 
@@ -1880,7 +1881,6 @@ class EventArrayTestCase(unittest.TestCase):
 
         # with mocked data
         accel._data = [fakeObject]
-        accel._firstTime = 3
         self.assertEqual(accel.getInterval(), (3, 1))
         self.assertEqual(accel._lastTime, 1)
 

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -1736,8 +1736,8 @@ class EventArrayTestCase(unittest.TestCase):
         self.assertEqual(self.eventArray1.session, self.dataset.sessions[0])
         self.assertEqual(self.eventArray1.subchannelId, None)
 
-        # self.assertEqual(self.eventArray1._blockIndicesArray.size, 0)
-        # self.assertEqual(self.eventArray1._blockTimesArray.size, 0)
+        self.assertEqual(self.eventArray1._blockIndicesArray.size, 0)
+        self.assertEqual(self.eventArray1._blockTimesArray.size, 0)
 
     # TODO add test
     #def test_JoinTimesValues(self):

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -1736,8 +1736,8 @@ class EventArrayTestCase(unittest.TestCase):
         self.assertEqual(self.eventArray1.session, self.dataset.sessions[0])
         self.assertEqual(self.eventArray1.subchannelId, None)
 
-        self.assertEqual(self.eventArray1._blockIndicesArray.size, 0)
-        self.assertEqual(self.eventArray1._blockTimesArray.size, 0)
+        # self.assertEqual(self.eventArray1._blockIndicesArray.size, 0)
+        # self.assertEqual(self.eventArray1._blockTimesArray.size, 0)
 
     # TODO add test
     #def test_JoinTimesValues(self):
@@ -2463,7 +2463,7 @@ class EventArrayTestCase(unittest.TestCase):
         )
         args = (mock.sentinel.startTime, mock.sentinel.endTime,
                 mock.sentinel.padding, mock.sentinel.times,
-                mock.sentinel.display)
+                mock.sentinel.display, mock.sentinel.iterator)
 
         self.assertEqual(EventArray.getMinMeanMax(eventArray, *args),
                          mock.sentinel.return_value)


### PR DESCRIPTION
The main change is the addition of an `iterator` argument to several methods, specifically ones that return lists of things. This allows a means of long-running methods to be cancelled (e.g., from another thread) via an iterator/generator function that checks for cancellation. 

Semi-pseudocode example of such an iterator function:
```python
quit_condition = threading.Event()

def iterator(iterable):
    for i in iterable:
        if quit_condition.is_set():
            return
        yield i
```
This seemed like the easiest, most flexible, and lowest-impact means of adding a way to bail from a long-running synchronous loop. It aborts gracefully, however, so it it is up to the user to know that the resulting data may be incomplete.