### PR TITLE
Feature/update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
   include:
     # This build is stalling after passing, not sure why.  Since python 3.5 is currently being tested, skip for now
     # Windows doesn't support native python yet, so here we are - 3.5
-     - os: windows
-       language: shell
-       env: PATH=/c/python35:/c/Python35/scripts:$PATH
-       before_install:
-         - choco install python3 --version=3.5.4
-         - python -m pip install virtualenv
-         - virtualenv $HOME/venv
-         - source $HOME/venv/Scripts/activate
+    - os: windows
+      language: shell
+      env: PATH=/c/python35:/c/Python35/scripts:$PATH
+      before_install:
+        - choco install python3 --version=3.5.4
+        - python -m pip install virtualenv
+        - virtualenv $HOME/venv
+        - source $HOME/venv/Scripts/activate
     # Windows doesn't support native python yet, so here we are - 3.6
     - os: windows
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,22 @@ before_install:
   - python --version
 install:
   - pip install .[test]
-script: python -m pytest ./testing/ --cov=idelib-archive
+script: python -m pytest ./testing/ --cov=idelib
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)
 
 matrix:
   include:
     # This build is stalling after passing, not sure why.  Since python 3.5 is currently being tested, skip for now
     # Windows doesn't support native python yet, so here we are - 3.5
-    # - os: windows
-    #   language: shell
-    #   env: PATH=/c/python35:/c/Python35/scripts:$PATH
-    #   before_install:
-    #     - choco install python3 --version=3.5.4
-    #     - python -m pip install virtualenv
-    #     - virtualenv $HOME/venv
-    #     - source $HOME/venv/Scripts/activate
+     - os: windows
+       language: shell
+       env: PATH=/c/python35:/c/Python35/scripts:$PATH
+       before_install:
+         - choco install python3 --version=3.5.4
+         - python -m pip install virtualenv
+         - virtualenv $HOME/venv
+         - source $HOME/venv/Scripts/activate
     # Windows doesn't support native python yet, so here we are - 3.6
     - os: windows
       language: shell


### PR DESCRIPTION
Separating out the caching to a few PRs.

This updates travis to deal with codecov.io properly and adds python 3.5 testing back for windows.