### PR TITLE
Feature/utype api v1

### DIFF
--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2689,6 +2689,23 @@ class EventArray(Transformable):
         return self.arraySlice(startIdx, stopIdx, step, display=display)
 
 
+    def toPandas(self):
+        """ Copy data to a `pandas.DataFrame` object.
+        """
+        import pandas as pd
+
+        data = self.arraySlice()
+
+        if isinstance(self.parent, SubChannel):
+            columns = [self.parent.axisName]
+        elif isinstance(self.parent, Channel):
+            columns = [self.parent.subchannels[i].axisName for i in None]
+
+        return pd.DataFrame(
+            data[1:].T,
+            columns=columns,
+        )
+
     def exportCsv(self, stream, start=None, stop=None, step=1, subchannels=True,
                   callback=None, callbackInterval=0.01, timeScalar=1,
                   raiseExceptions=False, dataFormat="%.6f", delimiter=", ",


### PR DESCRIPTION
This draft PR is a concept piece for adding get-data-by-unit-type functions to `idelib`. The implementation proposed here is to make these functions available as `Dataset` methods that return data in the form of `EventArray`s or collections thereof.

This proposal is conditioned on an internal change to `EventArray`. Specifically, here `EventArray` objects would need to bind together data from an arbitrary subset of subchannels located in a single channel, as opposed to `EventArray`'s current configuration where they either represent data from all subchannels or just a single subchannel. This change is being worked on in another branch not yet pushed to GitHub.

This PR also includes a somewhat poorly-written `EventArray.toPandas` method that is dependent on some eventual specifics from the `EventArray` changes described above. This implementation will likely need to be tweaked, but the idea's there I guess. It could also be moved to a different PR.