### PR TITLE
Made some string splits safer

### DIFF
--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -943,7 +943,10 @@ class SubChannel(Channel):
                 name = name.decode()
             self.name = name
             if axisName is None:
-                self.axisName = self.name.split()[0]
+                if self.name:
+                    self.axisName = self.name.split()[0]
+                else:
+                    self.axisName = name
         
         # XXX: HACK HACK HACK REMOVE ME REMOVE ME
         if self.name == "Control Pad P":

--- a/idelib/transforms.py
+++ b/idelib/transforms.py
@@ -611,14 +611,14 @@ class CombinedPoly(Bivariate):
                     return
             phead, src = "lambda x", "x"
         else:
-            phead, src = self.poly.source.split(": ")
+            phead, _, src = self.poly.source.partition(": ")
             
         for k, v in self.subpolys.items():
             if v is None:
                 ssrc = "lambda x: x"
             else:
                 ssrc = v.source 
-            s = "(%s)" % ssrc.split(": ")[-1]
+            s = "(%s)" % ssrc.rpartition(": ")[-1]
             src = self._reduce(src.replace(k, s))
 
         if self._subchannel is not None:
@@ -688,7 +688,7 @@ class PolyPoly(CombinedPoly):
             if p is None:
                 body.append('x%d' % n)
             else:
-                body.append(p.source.split(':')[-1].replace('x', 'x%d' % n))
+                body.append(p.source.rpartition(':')[-1].replace('x', 'x%d' % n))
         
         # ends with a comma to ensure a tuple is returned
         src = "(%s,)" % (', '.join(body))

--- a/idelib/transforms.py
+++ b/idelib/transforms.py
@@ -944,14 +944,14 @@ class CombinedPoly(Bivariate):
                 if p is not None:
                     for attr in ('_str', '_source', '_function', '_noY'):
                         setattr(self, attr, getattr(p, attr, None))
-        phead, src = self.poly.source.split(": ")
-            
+        phead, _, src = self.poly.source.partition(": ")
+
         for k, v in self.subpolys.items():
             if v is None:
                 ssrc = "lambda x: x"
             else:
                 ssrc = v.source 
-            s = "(%s)" % ssrc.split(": ")[-1]
+            s = "(%s)" % ssrc.rpartition(": ")[-1]
             src = self._reduce(src.replace(k, s))
 
         if self._subchannel is not None:
@@ -1276,7 +1276,7 @@ class PolyPoly(CombinedPoly):
             if p is None:
                 body.append('x%d' % n)
             else:
-                body.append(p.source.split(':')[-1].replace('x', 'x%d' % n))
+                body.append(p.source.rpartition(':')[-1].replace('x', 'x%d' % n))
         
         # ends with a comma to ensure a tuple is returned
         src = "(%s,)" % (', '.join(body))

--- a/idelib/transforms.py
+++ b/idelib/transforms.py
@@ -951,8 +951,8 @@ class CombinedPoly(Bivariate):
                 ssrc = "lambda x: x"
             else:
                 ssrc = v.source
-            start, _, end = "(%s)" % ssrc.rpartition(": ")
-            s = end or start
+            start, _, end = ssrc.rpartition(": ")
+            s = "(%s)" % (end or start)
             src = self._reduce(src.replace(k, s))
 
         if self._subchannel is not None:

--- a/idelib/transforms.py
+++ b/idelib/transforms.py
@@ -950,8 +950,9 @@ class CombinedPoly(Bivariate):
             if v is None:
                 ssrc = "lambda x: x"
             else:
-                ssrc = v.source 
-            s = "(%s)" % ssrc.rpartition(": ")[-1]
+                ssrc = v.source
+            start, _, end = "(%s)" % ssrc.rpartition(": ")
+            s = end or start
             src = self._reduce(src.replace(k, s))
 
         if self._subchannel is not None:
@@ -1276,7 +1277,8 @@ class PolyPoly(CombinedPoly):
             if p is None:
                 body.append('x%d' % n)
             else:
-                body.append(p.source.rpartition(':')[-1].replace('x', 'x%d' % n))
+                start, _, end = p.source.rpartition(':')
+                body.append((end or start).replace('x', 'x%d' % n))
         
         # ends with a comma to ensure a tuple is returned
         src = "(%s,)" % (', '.join(body))


### PR DESCRIPTION
In a few places, strings were being split and indexed into with the assumption they contain something. This is fine for properly-constructed IDE files, but some recordings from prototypes had null strings for subchannel names. Even though users shouldn't ever see files like these, it's kind of sloppy not to handle them.

Fix is a test for null strings in one place, and changing to `partition()`/`rpartition()` (which always produces 3 items) elsewhere.

Pretty minor overall.

(This replaces PR #52, which was accidentally merging into `main`.)