### PR TITLE
Feature/fix integer get item

### DIFF
--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -1697,7 +1697,7 @@ class EventArray(Transformable):
 
             t = block.startTime + self._getBlockSampleTime(blockIdx)*subIdx
             tx = t
-            val = self.parent.parseBlock(block, start=subIdx, end=subIdx+1)[:, 0]
+            val = self.parent.parseBlock(block, start=subIdx, end=subIdx+1)[:, [0]]
 
             valx = retryUntilReturn(
                 partial(xform.inplace, val, timestamp=t, session=self.session,
@@ -1709,6 +1709,8 @@ class EventArray(Transformable):
             )
             if valx is None:
                 return None
+
+            valx = valx[:, 0]
 
             m = self._getBlockRollingMean(blockIdx)
             if m is not None:

--- a/testing/test_new_dataset.py
+++ b/testing/test_new_dataset.py
@@ -149,3 +149,14 @@ class TestEventArray:
     def test_array_jittery_values(self, channel_8_eventarray, start, end, step, expected):
         values = channel_8_eventarray.arrayJitterySlice(start=start, end=end, step=step)[1, :]
         np.testing.assert_equal(values, expected)
+
+    @pytest.mark.parametrize('idx', [0, 500, 999, -1])
+    def test_getitem(self, channel_8_eventarray, idx):
+
+        if idx < 0:
+            x = 1000 + idx
+        else:
+            x = idx
+        expected = np.floor(np.array([x*1000, x, 1000*(x/1000)**2, 1000*(x/1000)**0.5]))
+
+        np.testing.assert_equal(channel_8_eventarray[idx], expected)

--- a/testing/test_new_dataset.py
+++ b/testing/test_new_dataset.py
@@ -110,6 +110,11 @@ def channel_8_eventarray(load_test_dataset):
 
 
 @pytest.fixture()
+def channel_8_0_eventarray(load_test_dataset):
+    yield load_test_dataset.channels[8].subchannels[0].getSession()
+
+
+@pytest.fixture()
 def channel_36_eventarray(load_test_dataset):
     yield load_test_dataset.channels[36].getSession()
 
@@ -151,7 +156,7 @@ class TestEventArray:
         np.testing.assert_equal(values, expected)
 
     @pytest.mark.parametrize('idx', [0, 500, 999, -1])
-    def test_getitem(self, channel_8_eventarray, idx):
+    def test_getitem_channel(self, channel_8_eventarray, idx):
 
         if idx < 0:
             x = 1000 + idx
@@ -160,3 +165,14 @@ class TestEventArray:
         expected = np.floor(np.array([x*1000, x, 1000*(x/1000)**2, 1000*(x/1000)**0.5]))
 
         np.testing.assert_equal(channel_8_eventarray[idx], expected)
+
+    @pytest.mark.parametrize('idx', [0, 500, 999, -1])
+    def test_getitem_subchannel(self, channel_8_0_eventarray, idx):
+
+        if idx < 0:
+            x = 1000 + idx
+        else:
+            x = idx
+        expected = np.floor(np.array([x*1000, x]))
+
+        np.testing.assert_equal(channel_8_0_eventarray[idx], expected)


### PR DESCRIPTION
Fixes an issue with integer indices in `EventArray.__getitem__` that was introduced with the inplace transforms.