### PR TITLE
Feature/auto deploy to pypi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,13 +1,13 @@
-name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   push:
     branches:
-      - test/main
+      - main
 
 jobs:
   build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to TestPyPI
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-18.04
 
     steps:
@@ -34,15 +34,9 @@ jobs:
         --outdir dist/
         .
 
-    - name: Publish distribution 📦 to Test PyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}
         verbose: true
-    #- name: Publish distribution 📦 to PyPI
-    #  if: startsWith(github.ref, 'refs/tags')
-    #  uses: pypa/gh-action-pypi-publish@master
-    #  with:
-    #    password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    name: Build and publish Python 🐍 distributions 📦 to TestPyPI
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -34,8 +34,10 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
+        user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+        verbose: true
     #- name: Publish distribution 📦 to PyPI
     #  if: startsWith(github.ref, 'refs/tags')
     #  uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    branches:
+      - test/main
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,43 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@master
+    
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    #- name: Publish distribution 📦 to PyPI
+    #  if: startsWith(github.ref, 'refs/tags')
+    #  uses: pypa/gh-action-pypi-publish@master
+    #  with:
+    #    password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action to automatically deploy a new version to PYPI whenever a branch is merged into `main`.

### Background
More details & discussion are described in [our Confluence notes](https://midetech.atlassian.net/wiki/spaces/EC/pages/1202946049/automatic+PYPI+deployment+for+ebmlite+idelib). With reference to [the deployment triggering options](https://midetech.atlassian.net/wiki/spaces/EC/pages/1410105359/How+should+the+deployment+action+trigger), this PR is an implementation of method 1).

Regarding testing, this GitHub Action has been tested on [the `test/main` branch](https://github.com/MideTechnology/idelib/tree/test/main), and seems to have successfully deployed a version to [PYPI's test server](https://test.pypi.org/project/idelib/#history).

### Reviewer Notes
I'm marking this as a draft PR because there's a handful of questions I think we should discuss before pushing the button:
- should it also be conditioned on the branch having a "release tag"?
- do we want [branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests) on `main`? E.g., we could require PR's & approvals for any merges into `main`, which would help to prevent erroneous version deployments.