### PR TITLE
Feature/70 import range

### DIFF
--- a/idelib/importer.py
+++ b/idelib/importer.py
@@ -101,35 +101,6 @@ DEFAULTS = {
 }
 
 
-# if False: #__DEBUG__:
-#     logger.info("Adding low g channels to defaults")
-#     DEFAULTS['sensors'][0x02] = {
-#          'name': "Low-G Accelerometer"
-#     }
-#     DEFAULTS['channels'].update({
-#         0x02: {'name': "Low-G Accelerometer XYZ",
-#                'parser': struct.Struct(">hhh"),
-#                "subchannels":{0: {"name": "Low-g Z",
-#                                   "units":('Acceleration','g'),
-#                                   "sensorId": 2,
-#                                  },
-#                               1: {"name": "Low-g Y",
-#                                   "units":('Acceleration','g'),
-#                                   "sensorId": 2,
-#                                   },
-#                               2: {"name": "Low-g X",
-#                                   "units":('Acceleration','g'),
-#                                   "sensorId": 2,
-#                                   },
-#                             },
-#                },
-# #         0x43: {"name": "DEBUG Crystal Drift",
-# #                "parser": struct.Struct(">II")},
-# #         0x45: {"name": "DEBUG Gain/Offset",
-# #                "parser": struct.Struct("<i")},
-#     })
-
-
 def createDefaultSensors(doc, defaults=None):
     """ Given a nested set of dictionaries containing the definition of one or
         more sensors, instantiate those sensors and add them to the dataset

--- a/idelib/multi_importer.py
+++ b/idelib/multi_importer.py
@@ -1,15 +1,14 @@
-'''
-Functions for opening multiple IDE files as one. 
+"""
+Functions for opening multiple IDE files as one.
 
 :todo: Consider moving the rest of this into the normal `importer` module.
 
-'''
+"""
 
 import fnmatch
 import os.path
 
 from .importer import openFile, readData
-from .importer import NullUpdater
 
 
 #===============================================================================
@@ -26,7 +25,6 @@ if __DEBUG__:
     logger.setLevel(logging.INFO)
 else:
     logger.setLevel(logging.ERROR)
-
 
 
 #===============================================================================
@@ -94,8 +92,8 @@ def multiOpen(streams, updater=None, **kwargs):
         :keyword quiet: If `True`, non-fatal errors (e.g. schema/file
             version mismatches) are suppressed. 
     """
-    updater = updater or NullUpdater
-    updater(0)
+    if updater:
+        updater(0)
     
     docs = [openFile(f, **kwargs) for f in streams]
     docs.sort(key=lambda x: x.lastSession.utcStartTime)
@@ -129,8 +127,6 @@ def multiRead(doc, updater=None, **kwargs):
             of sensors, channels, and subchannels. These will only be used if
             the dataset contains no sensor/channel/subchannel definitions. 
     """
-    updater = updater or NullUpdater
-
     kwargs['numUpdates'] = kwargs.get('numUpdates', 500) / (len(doc.subsets)+1)
     totalSize = sum([x.ebmldoc.size for x in doc.subsets])
     bytesRead = doc.ebmldoc.size
@@ -143,10 +139,12 @@ def multiRead(doc, updater=None, **kwargs):
                                     bytesRead=bytesRead, samplesRead=samplesRead, 
                                     **kwargs)
             bytesRead += f.ebmldoc.size
-            updater(count=bytesRead, total=totalSize, 
-                    percent=bytesRead/(totalSize+0.0))
-        
-    updater(done=True, total=samplesRead)
+            if updater:
+                updater(count=bytesRead, total=totalSize,
+                        percent=bytesRead/(totalSize+0.0))
+
+    if updater:
+        updater(done=True, total=samplesRead)
     return doc
     
 

--- a/testing/test_import.py
+++ b/testing/test_import.py
@@ -1,3 +1,6 @@
+"""
+Tests for special features of the importing functions.
+"""
 import os.path
 
 import pytest  # type: ignore
@@ -10,17 +13,35 @@ from testing.file_streams import makeStreamLike
 #
 # ==============================================================================
 
-class TestImport:
+def _functionlike(cls):
+    """ Decorator for a singleton callable class. """
+    return cls()
+
+
+@_functionlike
+class NullUpdater:
+    """ A progress updater stand-in that does nothing. """
+    cancelled = False
+    paused = False
+
+    def __call__(self, *args, **kwargs):
+        if kwargs.get('error', None) is not None:
+            raise kwargs['error']
+
+
+# ==============================================================================
+#
+# ==============================================================================
+
+class TestImportRange:
 
     def test_import_updater(self):
         """
         Test importing with an updater
         """
         doc = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
-        importer.readData(doc, updater=importer.NullUpdater)
+        importer.readData(doc, updater=NullUpdater)
 
-
-class TestImportRange:
 
     @classmethod
     def setup_class(cls):

--- a/testing/test_import.py
+++ b/testing/test_import.py
@@ -1,0 +1,95 @@
+import os.path
+
+import pytest  # type: ignore
+
+from idelib import importer
+from testing.file_streams import makeStreamLike
+
+
+# ==============================================================================
+#
+# ==============================================================================
+
+class TestImport:
+
+    def test_import_updater(self):
+        """
+        Test importing with an updater
+        """
+        doc = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+        importer.readData(doc, updater=importer.NullUpdater)
+
+
+class TestImportRange:
+
+    @classmethod
+    def setup_class(cls):
+        cls.dataset = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+        importer.readData(cls.dataset)
+
+        cls.extractionStart = cls.dataset.sessions[0].lastTime * .33
+        cls.extractionEnd = cls.extractionStart * 2
+
+        cls.dataset.close()
+
+
+    def test_import_startTime(self):
+        """
+        Test importing a range with only start time specified.
+        """
+        doc = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+        importer.readData(doc,
+                          startTime=self.extractionStart,
+                          endTime=None,
+                          channels=None)
+
+        for channel in doc.channels.values():
+            data = channel.getSession()
+            assert data[0][0] <= self.extractionStart
+
+
+    def test_import_endTime(self):
+        """
+        Test importing a range with only end time specified.
+        """
+        doc = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+        importer.readData(doc,
+                          startTime=0,
+                          endTime=self.extractionEnd,
+                          channels=None)
+
+        for channel in doc.channels.values():
+            data = channel.getSession()
+            assert data[-1][0] >= self.extractionEnd
+
+
+    def test_import_startTime_endTime(self):
+        """
+        Test importing a range with both start and end times specified.
+        """
+        doc = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+        importer.readData(doc,
+                          startTime=self.extractionStart,
+                          endTime=self.extractionEnd,
+                          channels=None)
+
+        for channel in doc.channels.values():
+            data = channel.getSession()
+            assert data[0][0] <= self.extractionStart
+            assert data[-1][0] >= self.extractionEnd
+
+
+    def test_import_channels(self):
+        """
+        Test that only data from specified channels is imported.
+        """
+        doc = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+        importer.readData(doc,
+                          channels=[8, 36])
+
+        assert len(doc.channels[8].getSession()) > 0, \
+            "Imported file did not contain data for specified channel"
+        assert len(doc.channels[36].getSession()) > 0, \
+            "Imported file did not contain data for specified channel"
+        assert len(doc.channels[32].getSession()) == 0, \
+            "Imported file contains data from excluded channel"


### PR DESCRIPTION
This reworks the `util.extractTime()` logic introduced in PR #60 to be more general, adding the ability to import a specific time range from a file.