### PR TITLE
fixed `DeprecationWarning` triggering in `importFile`

### DIFF
--- a/idelib/importer.py
+++ b/idelib/importer.py
@@ -276,9 +276,12 @@ def importFile(filename='', startTime=None, endTime=None, channels=None,
     """
     # FUTURE: Remove `kwargs` and this conditional warning.
     if kwargs:
-        warnings.warn(DeprecationWarning(
-                'Some importFile() updater-related arguments have been deprecated. '
-                'Ignored arguments: {}'.format(', '.join(repr(k) for k in kwargs))))
+        warnings.warn(
+            'Some importFile() updater-related arguments have been deprecated.'
+            ' Ignored arguments: {}'.format(', '.join(kwargs)),
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     defaults = defaults or DEFAULTS
 
@@ -512,9 +515,12 @@ def readData(doc, source=None, startTime=None, endTime=None, channels=None,
 
     # FUTURE: Remove `kwargs` and this conditional warning.
     if kwargs:
-        warnings.warn(DeprecationWarning(
-                'Some readData() updater-related arguments have been deprecated. '
-                'Ignored arguments: {}'.format(', '.join(repr(k) for k in kwargs))))
+        warnings.warn(
+            'Some importFile() updater-related arguments have been deprecated.'
+            ' Ignored arguments: {}'.format(', '.join(kwargs)),
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     parserTypes = parserTypes or ELEMENT_PARSER_TYPES
     if doc._parsers is None:

--- a/idelib/importer.py
+++ b/idelib/importer.py
@@ -286,7 +286,7 @@ def importFile(filename='', startTime=None, endTime=None, channels=None,
     doc = openFile(stream, updater=updater, name=name, parserTypes=parserTypes,
                    defaults=defaults, quiet=quiet)
     readData(doc, startTime=startTime, endTime=endTime, channels=channels,
-             updater=updater, parserTypes=parserTypes, defaults=defaults)
+             updater=updater, parserTypes=parserTypes)
     return doc
 
 


### PR DESCRIPTION
resolves #79

This PR includes c468a72d828fbe9926991c5cb54cd04ba8bab6a3, which reformats the deprecation warnings in `importFile` & `readData` to provide more intuitive warnings. (see [the `warnings.warn` docs](https://docs.python.org/3.6/library/warnings.html#warnings.warn) for details; the big advantage in user-friendliness is in setting the `stacklevel` parameter.)