### PR TITLE
Feature/86 fix minmeanmax transform

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,7 @@ jobs:
     name: Run Unit Tests
 
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -2205,9 +2205,9 @@ class EventArray(Transformable):
                 _mean = d.mean
                 _max = d.max
 
-            xform.inplace(_min, timestamp=t, out=out[0, idx, i])
-            xform.inplace(_mean, timestamp=t, out=out[1, idx, i])
-            xform.inplace(_max, timestamp=t, out=out[2, idx, i])
+            out[0, idx, i] = xform.inplace(_min, timestamp=t)
+            out[1, idx, i] = xform.inplace(_mean, timestamp=t)
+            out[2, idx, i] = xform.inplace(_max, timestamp=t)
 
         for i in range(1, shape[1]):
             if i == 0 and time:

--- a/idelib/transforms.py
+++ b/idelib/transforms.py
@@ -1376,7 +1376,10 @@ class PolyPoly(CombinedPoly):
             if self._noY is False:
                 if noBivariates:
                     for i, poly in enumerate(self.polys):
-                        poly.inplace(values[i], y=0, out=out[i])
+                        if np.isscalar(out[i]):
+                            out[i] = poly.inplace(values[i], y=0)
+                        else:
+                            poly.inplace(values[i], y=0, out=out[i])
                     return out
 
                 session = self.dataset.lastSession if session is None else session
@@ -1398,12 +1401,18 @@ class PolyPoly(CombinedPoly):
                     y = self._eventlist.getMean()
 
                 for i, poly in enumerate(self.polys):
-                    poly.inplace(values[i], y=y, out=out[i])
+                    if np.isscalar(out[i]):
+                        out[i] = poly.inplace(values[i], y=y)
+                    else:
+                        poly.inplace(values[i], y=y, out=out[i])
                 return out
 
             else:
                 for i, poly in enumerate(self.polys):
-                    poly.inplace(values[i], out=out[i])
+                    if np.isscalar(out[i]):
+                        out[i] = poly.inplace(values[i])
+                    else:
+                        poly.inplace(values[i], out=out[i])
                 return out
 
         except (TypeError, IndexError, ZeroDivisionError) as err:

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -1377,36 +1377,44 @@ class TestEventArray:
                 eventArray.arraySlice(),
                 )
 
-    @unittest.skip('failing, poorly formed')
-    def testIterMinMeanMax(self, eventArray1):
+    def testIterMinMeanMax(self, eventArray):
         """ Test for iterMinMeanMax method. """
-        self.mockData()
-        eventArray1._data[0].minMeanMax = 1
-        eventArray1._data[0].blockIndex = 2
-        eventArray1._data[0].min = [3]
-        eventArray1._data[0].mean = [4]
-        eventArray1._data[0].max = [5]
 
-        self.assertListEqual(
-            [x for x in eventArray1.iterMinMeanMax()],
-            [((0, 3), (0, 4), (0, 5))]
-        )
-
-    def testArrayMinMeanMax(self, eventArray):
-        """ Test arrayMinMeanMax. """
+        # modify transform to ensure that transforms are being applied properly
+        eventArray.parent.dataset.transforms[9].coefficients = (2., 0.)
+        eventArray.parent.dataset.updateTransforms()
 
         expected = np.zeros((3, 4, 10))
         expected[:, 0, :] = np.linspace(0, 900000, 10)
-        expected[1, 1, :] = 499
-        expected[1, 2, :] = 332
-        expected[1, 3, :] = 666
-        expected[2, 1, :] = 999
-        expected[2, 2, :] = 998
-        expected[2, 3, :] = 999
+        expected[1, 1, :] = 499*2
+        expected[1, 2, :] = 332*2
+        expected[1, 3, :] = 666*2
+        expected[2, 1, :] = 999*2
+        expected[2, 2, :] = 998*2
+        expected[2, 3, :] = 999*2
 
         # Run tests
         result = eventArray.arrayMinMeanMax()
         print(result[:, 0, :])
+        np.testing.assert_array_equal(result, expected)
+
+    def testArrayMinMeanMax(self, eventArray):
+        """ Test arrayMinMeanMax. """
+
+        eventArray.parent.dataset.transforms[9].coefficients = (2., 0.)
+        eventArray.parent.dataset.updateTransforms()
+
+        expected = np.zeros((3, 4, 10))
+        expected[:, 0, :] = np.linspace(0, 900000, 10)
+        expected[1, 1, :] = 499*2
+        expected[1, 2, :] = 332*2
+        expected[1, 3, :] = 666*2
+        expected[2, 1, :] = 999*2
+        expected[2, 2, :] = 998*2
+        expected[2, 3, :] = 999*2
+
+        # Run tests
+        result = eventArray.arrayMinMeanMax()
         np.testing.assert_array_equal(result, expected)
 
     def testGetMinMeanMax(self, testIDE):


### PR DESCRIPTION
Fixes an issue where the method `arrayMinMeanMax` wasn't using calibrated data, as well as some other issues that cropped up involving `PolyPoly` transforms.