### PR TITLE
Added `<SerialCommandInterface>` to `<RecorderInfo>`

### DIFF
--- a/idelib/schemata/mide_ide.xml
+++ b/idelib/schemata/mide_ide.xml
@@ -92,6 +92,7 @@
             <StringElement name="McuType" id="0x521E" multiple="0" minver="1">Code indicating the type of CPU.</StringElement>
             <StringElement name="BootloaderRevStr" id="0x521F" multiple="0" minver="1">Bootloader revision string.</StringElement>
             <UIntegerElement name="BootloaderRev" id="0x5220" multiple="0" minver="1">Incrementing bootloader revision level</UIntegerElement>
+            <MasterElement name="SerialCommandInterface" id="0x5230" multiple="0" minver="2" mandatory="0">Present in the device's DEVINFO if it supports control via serial</MasterElement>
         </MasterElement>
         <!-- SensorList and PlotList are optional; there are defaults that will be used. The use of defaults is all-or-nothing; the file should define all sensors or have no SensorList at all. -->
         <MasterElement name="SensorList" id="0x5240" multiple="0" minver="2">Master element for the SensorList items


### PR DESCRIPTION
Minor change to the schema to support the upcoming firmware's serial command interface. Even though this is primarily a device thing, `idelib` keeps the canonical copy of the `mide_ide.xml` EBML schema.