### PR TITLE
Feature/12 schema path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import idelib
 # -- Project information -----------------------------------------------------
 
 project = 'idelib'
-copyright = '2021, Mide Technology Corp.'
+copyright = '2022, Mide Technology Corp.'
 author = 'David Randall Stokes'
 
 # The short X.Y version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.ifconfig',
     'sphinx.ext.githubpages',
+    'nbsphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -61,7 +62,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/idelib/__init__.py
+++ b/idelib/__init__.py
@@ -5,12 +5,19 @@ files.
 """
 
 __author__ = "David Randall Stokes"
-__copyright__ = "Copyright (c) 2021 Midé Technology"
+__copyright__ = "Copyright (c) 2022 Midé Technology"
 
-__maintainer__ = "Mide Technology"
+__maintainer__ = "Midé Technology"
 __email__ = "help@mide.com"
 
 __version__ = (3, 2, 4)
 __status__ = "Production/Stable"
 
 from .importer import importFile
+
+# Add EBML schema path to ebmlite search paths
+import ebmlite
+
+SCHEMA_PATH = "{idelib}/schemata"
+if SCHEMA_PATH not in ebmlite.SCHEMA_PATH:
+    ebmlite.SCHEMA_PATH.insert(0, SCHEMA_PATH)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pytest>=4.6
 pytest-xdist[psutil]
 mock
 pytest-cov
-sphinx
+sphinx==4.2.0
 scipy;python_version<"3.10"

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ TEST_REQUIRES = [
     'pytest-xdist[psutil]',
     'mock',
     'pytest-cov',
-    'sphinx',
+    'sphinx==4.2.0',
     'scipy;python_version<"3.10"',
     ]
 
 DOCS_REQUIRES = [
-    "sphinx",
+    "sphinx==4.2.0",
     "pydata-sphinx-theme",
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ TEST_REQUIRES = [
 DOCS_REQUIRES = [
     "sphinx==4.2.0",
     "pydata-sphinx-theme",
+    "nbsphinx",
     ]
 
 EXAMPLE_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ TEST_REQUIRES = [
 
 DOCS_REQUIRES = [
     "sphinx==4.2.0",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme==0.7.2",
     "nbsphinx",
     ]
 

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -285,7 +285,6 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(self.dataset.plots, {})
         self.assertEqual(self.dataset.recorderConfig, None)
         self.assertEqual(self.dataset.recorderInfo, {})
-        self.assertEqual(self.dataset.schemaVersion, 2)
         self.assertEqual(self.dataset.sensors, {})
         self.assertEqual(self.dataset.sessions, [])
         self.assertEqual(self.dataset.subsets, [])


### PR DESCRIPTION
This adds the module-relative schema path to `ebmlite.SCHEMA_PATH`, ensuring the correct `mide_ide.xml` schema is loaded.

Changes were also made to pin some Sphinx-related version requirements. Updates to some packages broke doc generation in Python >3.6. It was probably `pydata-sphinx-theme`, but some other package versions were pinned, just in case.