### PR TITLE
Updates for Python 3.11

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@master
     
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
     

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        exclude:
+          - os: ubuntu-latest
+            python-version: '3.6'
 
     env:
       OS: ${{ matrix.os }}
@@ -22,12 +25,12 @@ jobs:
 
     steps:
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: python -m pip install .[test,docs]
 
@@ -35,7 +38,7 @@ jobs:
       - run: sphinx-build -W -b html docs docs/html
       - run: sphinx-build -W -b doctest docs docs/doctest
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON-VERSION

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setuptools.setup(
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',
+                     'Programming Language :: Python :: 3.11',
                      'Topic :: Scientific/Engineering',
                      ],
         keywords='ebml binary ide mide',
@@ -60,7 +61,7 @@ setuptools.setup(
             "Source Code": "https://github.com/MideTechnology/idelib",
             },
         test_suite='./testing',
-        python_requires='>=3.5, <3.11',
+        python_requires='>=3.5',
         install_requires=INSTALL_REQUIRES,
         extras_require={
             'test': INSTALL_REQUIRES + TEST_REQUIRES,


### PR DESCRIPTION
Updated various actions to v3. Updated tests to cover up to Python 3.11, skipping Ubuntu 3.6. Removed max Python version