### PR TITLE
Bugfix/es 544 min mean max

### DIFF
--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -1430,9 +1430,9 @@ class EventArray(Transformable):
                 #  in _computeMinMeanMax(). Causes issues with pressure for some
                 #  reason - it starts removing mean and won't plot.
                 vals = np_recfunctions.structured_to_unstructured(block.payload.view(self._npType))
-                block.min = vals.min(axis=-1)
-                block.mean = vals.mean(axis=-1)
-                block.max = vals.max(axis=-1)
+                block.min = vals.min(axis=-2)
+                block.mean = vals.mean(axis=-2)
+                block.max = vals.max(axis=-2)
                 self.hasMinMeanMax = True
 
             # Cache the index range for faster searching

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -1430,9 +1430,9 @@ class EventArray(Transformable):
                 #  in _computeMinMeanMax(). Causes issues with pressure for some
                 #  reason - it starts removing mean and won't plot.
                 vals = np_recfunctions.structured_to_unstructured(block.payload.view(self._npType))
-                block.min = vals.min(axis=-2)
-                block.mean = vals.mean(axis=-2)
-                block.max = vals.max(axis=-2)
+                block.min = vals.min(axis=0)
+                block.mean = vals.mean(axis=0)
+                block.max = vals.max(axis=0)
                 self.hasMinMeanMax = True
 
             # Cache the index range for faster searching


### PR DESCRIPTION
This issue was preventing the correct import from IDE Lib because the new press/temp sensor does not provide min/mean/max values, because it provides floating point data so that is just more math. The new IDE lib (as opposed to what endaq Lab uses) grabs the mean of the temp, and since that calc was getting screwed up it was throwing off the data.

I feel like some of our tests should have caught this. I also worry about min/mean/max calcs in other functions that use axis=-1