### PR TITLE
Updated to `__version__` pattern used in `endaq-python` and others

### DIFF
--- a/idelib/__init__.py
+++ b/idelib/__init__.py
@@ -5,12 +5,13 @@ files.
 """
 
 __author__ = "David Randall Stokes"
-__copyright__ = "Copyright (c) 2022 Midé Technology"
+__copyright__ = "Copyright (c) 2023 Midé Technology"
 
 __maintainer__ = "Midé Technology"
 __email__ = "help@mide.com"
 
-__version__ = (3, 2, 4)
+__version__ = '3.2.8'
+
 __status__ = "Production/Stable"
 
 from .importer import importFile

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,21 @@
+import codecs
+import os
 import setuptools
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
@@ -29,11 +46,11 @@ EXAMPLE_REQUIRES = [
 
 setuptools.setup(
         name='idelib',
-        version='3.2.8',
+        version=get_version('idelib/__init__.py'),
         author='Mide Technology',
         author_email='help@mide.com',
         description='Python API for accessing IDE data recordings',
-        long_description=long_description,
+        long_description=read('README.md'),
         long_description_content_type='text/markdown',
         url='https://github.com/MideTechnology/idelib',
         license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@ def get_version(rel_path):
         raise RuntimeError("Unable to find version string.")
 
 
-with open('README.md', 'r', encoding='utf-8') as fh:
-    long_description = fh.read()
-
 INSTALL_REQUIRES = [
     'numpy',
     'ebmlite>=3.1.0'


### PR DESCRIPTION
This is the pattern used in some other Mide packages, originating from this: https://packaging.python.org/en/latest/guides/single-sourcing-package-version/