### PR TITLE
Added non-sync-related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ docs/_build/
 docs/html/
 docs/latex/
 docs/doctest/
+docs/doctrees/
 
 # PyBuilder
 target/

--- a/docs/api_ref.rst
+++ b/docs/api_ref.rst
@@ -6,3 +6,5 @@
    :caption: Contents:
 
    idelib/dataset
+   idelib/importer
+   idelib/util

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,10 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
 import idelib
 
 # -- Project information -----------------------------------------------------

--- a/docs/idelib/dataset.rst
+++ b/docs/idelib/dataset.rst
@@ -1,5 +1,5 @@
-dataset.py
-============
+``idelib.dataset``
+==================
 
 .. automodule:: idelib.dataset
 

--- a/docs/idelib/importer.rst
+++ b/docs/idelib/importer.rst
@@ -1,0 +1,10 @@
+``idelib.importer``
+===================
+
+.. automodule:: idelib.importer
+
+.. autofunction:: idelib.importer.importFile
+
+.. autofunction:: idelib.importer.openFile
+
+.. autofunction:: idelib.importer.readData

--- a/docs/idelib/util.rst
+++ b/docs/idelib/util.rst
@@ -1,0 +1,5 @@
+``idelib.util``
+===============
+
+.. automodule:: idelib.util
+   :members:

--- a/idelib/__init__.py
+++ b/idelib/__init__.py
@@ -5,16 +5,18 @@ files.
 """
 
 __author__ = "David Randall Stokes"
-__copyright__ = "Copyright (c) 2024 Midé Technology"
+__copyright__ = "Copyright (c) 2025 Midé Technology"
 
 __maintainer__ = "Midé Technology"
 __email__ = "help@mide.com"
 
-__version__ = '3.3.0b1'
+__version__ = '3.4.0b1'
 
 __status__ = "Production/Stable"
 
-from .importer import importFile
+import logging
+logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
 
 # Add EBML schema path to ebmlite search paths
 import ebmlite
@@ -22,3 +24,5 @@ import ebmlite
 SCHEMA_PATH = "{idelib}/schemata"
 if SCHEMA_PATH not in ebmlite.SCHEMA_PATH:
     ebmlite.SCHEMA_PATH.insert(0, SCHEMA_PATH)
+
+from .importer import importFile

--- a/idelib/attributes.py
+++ b/idelib/attributes.py
@@ -10,12 +10,6 @@ import time
 
 from ebmlite import loadSchema
 
-# Dictionaries in Python 3.7+ are explicitly insert-ordered in all
-# implementations. If older, continue to use `collections.OrderedDict`.
-if sys.hexversion < 0x03070000:
-    from collections import OrderedDict as Dict
-else:
-    Dict = dict
 
 # ==============================================================================
 # 
@@ -27,7 +21,7 @@ def decode_attributes(data, withTypes=False):
         `FloatAttribute`, etc.) to a proper dictionary. Attributes are tagged
         as 'multiple,' so they become lists when the EBML is parsed.
     """
-    result = Dict()
+    result = {}
     for atts in data:
         k = atts.pop('AttributeName', None)
         if k is None:

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -606,93 +606,15 @@ class Session(object):
                 POSIX/epoch timestamp.
         """
         self.dataset: Dataset = dataset
+        self.startTime = startTime
+        self.endTime = endTime
         self.sessionId: int = sessionId
-        self.utcStartTimeOriginal: int = utcStartTime or dataset.lastUtcTime
-        self.utcStartTime: int = self.utcStartTimeOriginal
-
-        self._data: dict[int, 'EventArray'] = None
-        self._offset: float = 0
+        self.utcStartTime: int = utcStartTime or dataset.lastUtcTime
 
         # firstTime and lastTime are the actual last event time. These will
-        # typically be the same as startTime and endTime, which are being
-        # deprecated.
-        self.firstTimeOriginal: float = startTime
-        self.firstTime: float = startTime
-        self.lastTimeOriginal: float = endTime
-        self.lastTime: float = endTime
-
-        self.syncInfo: Optional[Dict[str, Any]] = None
-        self.syncSensor: Optional[Sensor] = None
-        self.syncZero: float = None
-
-
-    @property
-    def startTime(self) -> float:
-        warnings.warn('Session.startTime is deprecated, and will be removed '
-                      'in the near future. Use Session.firstTime instead. ',
-                      PendingDeprecationWarning)
-        return self.firstTime
-
-
-    # noinspection PyDeprecation
-    @startTime.setter
-    def startTime(self, val: float):
-        warnings.warn('Session.startTime is deprecated, and will be removed '
-                      'in the near future. Use Session.firstTime instead. ',
-                      PendingDeprecationWarning)
-        self.firstTime = val
-
-
-    @property
-    def endTime(self) -> float:
-        warnings.warn('Session.endTime is deprecated, and will be removed '
-                      'in the future. Use Session.lastTime instead. ',
-                      PendingDeprecationWarning)
-        return self.lastTime
-
-
-    # noinspection PyDeprecation
-    @endTime.setter
-    def endTime(self, val: float):
-        warnings.warn('Session.endTime is deprecated, and will be removed '
-                      'in the future. Use Session.lastTime instead. ',
-                      PendingDeprecationWarning)
-        self.lastTime = val
-
-
-    @property
-    def data(self) -> Dict[int, 'EventArray']:
-        """ All the Channel-level `EventArray` instances in this `Session`,
-            keyed by channel ID.
-        """
-        if not self._data or self.dataset.loading:
-            self._data = {}
-            for chid, ch in self.dataset.channels.items():
-                if self.sessionId in ch.sessions:
-                    self._data[chid] = ch.sessions[self.sessionId]
-        return self._data
-
-
-    @property
-    def offset(self) -> float:
-        """ A time offset (in microseconds) for all events, across all
-            Channels, in this `Session`.
-        """
-        return self._offset
-
-
-    @offset.setter
-    def offset(self, offset: float):
-        """ A time offset (in microseconds) for all events, across all
-            Channels, in this `Session`.
-        """
-        offset = offset or 0.
-        self._offset = offset
-        self.firstTime = self.firstTimeOriginal + offset
-        self.lastTime = self.lastTimeOriginal + offset
-        for d in self.data.values():
-            # TODO: Exclude non-relative time channels?
-            d._setOffset(offset)
+        # typically be the same as startTime and endTime, but not necessarily
+        # so.
+        self.firstTime = self.lastTime = None
 
 
     # noinspection PyDeprecation
@@ -704,7 +626,7 @@ class Session(object):
                                  self.sessionId,
                                  datetime.utcfromtimestamp(self.utcStartTime))
 
-    
+
     def __eq__(self, other):
         """ x.__eq__(y) <==> x==y """
         if other is self:
@@ -713,11 +635,14 @@ class Session(object):
             return False
         else:
             return self.dataset == other.dataset \
-               and self.sessionId == other.sessionId \
-               and self.utcStartTimeOriginal == other.utcStartTimeOriginal \
-               and self.firstTimeOriginal == other.firstTimeOriginal \
-               and self.lastTimeOriginal == other.lastTimeOriginal
-        
+                and self.startTime == other.startTime \
+                and self.endTime == other.endTime \
+                and self.sessionId == other.sessionId \
+                and self.utcStartTime == other.utcStartTime \
+                and self.firstTime == other.firstTime \
+                and self.lastTime == other.lastTime
+
+
 #===============================================================================
 # 
 #===============================================================================
@@ -1473,18 +1398,6 @@ class EventArray(Transformable):
             self._npType = np.dtype([(str(i), dtype) for i, dtype in enumerate(dtypes)])
 
 
-    def _setOffset(self, offset):
-        """ Apply an offset to the `EventArray` timestamps. Do not use
-            directly; use `Session.offset`.
-        """
-        for d in self._data:
-            d.startTime = d.startTimeOriginal + offset
-            d.endTime = d.endTimeOriginal + offset
-
-        # XXX: Can probably skip this if the dataset is loading
-        self._blockTimesArray = np.array(self._blockTimes, dtype=np.float64) + offset
-
-
     @property
     def rollingMeanSpan(self):
         return self._rollingMeanSpan
@@ -1577,14 +1490,14 @@ class EventArray(Transformable):
         # newList._cacheBlockStart = self._cacheBlockStart
         # newList._cacheBlockEnd = self._cacheBlockEnd
         return newList
-    
+
 
     def append(self, block):
         """ Add one data block's contents to the Channel's list of data.
             Note that this doesn't double-check the channel ID specified in
             the data, but it is inadvisable to include data from different
             channels.
-            
+
             :attention: Added elements must be in chronological order!
         """
         with self._channelDataLock:
@@ -1594,19 +1507,14 @@ class EventArray(Transformable):
             # Set the session first/last times if they aren't already set.
             # Possibly redundant if all sessions are 'closed.'
             if self.session.firstTime is None:
-                self.session.firstTimeOriginal = block.startTime
-                self.session.firstTime = block.startTime + self.session._offset
+                self.session.firstTime = block.startTime
             else:
-                self.session.firstTimeOriginal = min(self.session.firstTimeOriginal, block.startTime)
-                self.session.firstTime = self.session.firstTimeOriginal + self.session._offset
+                self.session.firstTime = min(self.session.firstTime, block.startTime)
 
             if self.session.lastTime is None:
-                self.session.lastTimeOriginal = block.endTime
-                self.session.lastTime = block.endTime + self.session._offset
+                self.session.lastTime = block.endTime
             else:
-                self.session.lastTimeOriginal = max(self.session.lastTimeOriginal, block.endTime)
-                self.session.lastTime = self.session.lastTimeOriginal + self.session._offset
-
+                self.session.lastTime = max(self.session.lastTime, block.endTime)
 
             # Check that the block actually contains at least one sample.
             if block.numSamples < 1:
@@ -1644,14 +1552,14 @@ class EventArray(Transformable):
                 self.hasMinMeanMax = False
             elif block.minMeanMax is not None:
                 mmmArr = np_recfunctions.structured_to_unstructured(
-                    np.frombuffer(block.minMeanMax, self._npType))
+                        np.frombuffer(block.minMeanMax, self._npType))
                 block.min, block.mean, block.max = mmmArr
                 self.hasMinMeanMax = True
             else:
                 # XXX: Attempt to calculate min/mean/max here instead of
                 #  in _computeMinMeanMax(). Causes issues with pressure for some
                 #  reason - it starts removing mean and won't plot.
-                vals: np.array = np_recfunctions.structured_to_unstructured(block.payload.view(self._npType))
+                vals = np_recfunctions.structured_to_unstructured(block.payload.view(self._npType))
                 block.min = vals.min(axis=0)
                 block.mean = vals.mean(axis=0)
                 block.max = vals.max(axis=0)
@@ -1724,8 +1632,7 @@ class EventArray(Transformable):
             :keyword start: The first block index to search
             :keyword stop: The last block index to search
         """
-        # TODO: profile & determine if this change is beneficial. I'm not
-        #  sure the new version was ever actually profiled vs. the old.
+        # TODO: profile & determine if this change is beneficial
         '''
         if stop:
             blockIdx = bisect_right(self._blockTimes, t, start, stop)
@@ -1736,18 +1643,12 @@ class EventArray(Transformable):
         return blockIdx
         '''
         if len(self._blockTimesArray) != len(self._blockTimes):
-            self._blockTimesArray = np.array(self._blockTimes, dtype=np.float64) + self.session._offset
-
-        if t is None or t < self._blockTimesArray[0]:
-            return 0
-        elif t > self._blockTimesArray[-1]:
-            return len(self._blockTimesArray)
+            self._blockTimesArray = np.array(self._blockTimes)
 
         idxOffset = max(start, 1)
         return idxOffset-1 + np.searchsorted(
             self._blockTimesArray[idxOffset:stop], t, side='right'
         )
-
 
     def _getBlockRollingMean_old(self, blockIdx, force=False):
         """ Get the mean of a block and its neighbors within a given time span.

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -49,8 +49,8 @@ __all__ = ['Channel', 'Dataset', 'EventArray', 'Plot', 'Sensor', 'Session',
 from collections.abc import Iterable, Sequence
 from datetime import datetime
 from math import ceil
-from threading import Lock
-from typing import Any, Dict, Optional
+from threading import RLock
+from typing import Any, Dict, List, Optional, Union, Type
 import warnings
 
 import os.path
@@ -73,8 +73,7 @@ SCHEMA_FILE = 'mide_ide.xml'
 #===============================================================================
 
 import logging
-logger = logging.getLogger('idelib')
-logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 __DEBUG__ = str(os.environ.get('MIDE_DEV', 0)) == '1'
     
@@ -94,6 +93,7 @@ def mapRange(x, in_min, in_max, out_min, out_max):
 #===============================================================================
 # Mix-In Classes
 #===============================================================================
+
 
 class Cascading(object):
     """ A base/mix-in class for objects in a hierarchy. 
@@ -134,10 +134,10 @@ class Transformable(Cascading):
         etc.), making it easy to turn the transformation on or off.
         
         :ivar transform: The transformation function/object
-        :ivar raw: If `False`, the transform will not be applied to data.
-            Note: The object's `transform` attribute will not change; it will
-            just be ignored.
     """
+
+    dataset: "Dataset" = None
+    children: List["Transformable"] = None
 
     def setTransform(self, transform, update=True):
         """ Set the transforming function/object. This does not change the
@@ -217,7 +217,6 @@ class Dataset(Cascading):
             A valid file will have at least one, even if there are no 
             `Session` elements in the data.
         :ivar sensors: A dictionary of Sensors.
-        :ivar channels: A dictionary of individual Sensor channels.
         :ivar plots: A dictionary of individual Plots, the modified output of
             a Channel (or even another plot).
         :ivar transforms: A dictionary of functions (or function-like objects)
@@ -248,6 +247,7 @@ class Dataset(Cascading):
         self.currentSession = None
         self.recorderInfo = {}
         self.recorderConfig = None
+        self.bandwidthLimits = {}  # For future use
 
         self.attributes = attributes if attributes else {}
 
@@ -262,9 +262,12 @@ class Dataset(Cascading):
         # For keeping user-defined data
         self._userdata: Optional[Dict[str, Any]] = None
         self._userdataOffset: Optional[int] = None
+        self._userdataOriginal: Optional[Dict[str, Any]] = None
         self._filesize: Optional[int] = None
 
-        self._channelDataLock = Lock()
+        self._fingerprint = None
+
+        self._channelDataLock = RLock()
         
         # Subsets: used when importing multiple files into the same dataset.
         self.subsets = []
@@ -309,7 +312,21 @@ class Dataset(Cascading):
         """ A dictionary of individual Sensor channels. """
         # Only return channels with subchannels. If all analog subchannels are
         # disabled, the recording properties will still show the parent channel.
-        return {k:v for k,v in self._channels.items() if v.subchannels}
+        return {k: v for k, v in self._channels.items() if v.subchannels}
+
+
+    @property
+    def fingerprint(self) -> Optional[str]:
+        """ A simple hash for identifying this `Dataset`, so it can be
+            referenced elsewhere, even if moved/renamed. The fingerprint
+            hash is generated from the recording's metadata, so modifying or
+            truncating the sensor data will not affect it. As such, the
+            fingerprint should not be used to verify file integrity.
+        """
+        try:
+            return self._fingerprint.hexdigest()
+        except AttributeError:
+            return None
 
 
     def close(self):
@@ -364,17 +381,20 @@ class Dataset(Cascading):
         """
         cs = self.currentSession
         if cs is not None:
-            if cs.startTime is None:
-                cs.startTime = cs.firstTime
-            if cs.endTime is None:
-                cs.endTime = cs.lastTime
-                
             self.currentSession = None
         
     
-    def addSensor(self, sensorId=None, name=None, sensorClass=None, 
-                  traceData=None, transform=None, attributes=None,
-                  bandwidthLimitId=None):
+    def addSensor(self,
+                  sensorId: Optional[int] = None,
+                  name: Optional[str] = None,
+                  sensorClass: Optional[Type] = None,
+                  sourceName: Optional[str] = None,
+                  sourceId: Optional[str] = None,
+                  relative: bool = False,
+                  traceData: Optional[Dict[str, Any]] = None,
+                  transform: Union[int, Transform, None] = None,
+                  attributes: Optional[Dict[str, Any]] = None,
+                  bandwidthLimitId: Optional[int] = None):
         """ Create a new Sensor object, and add it to the dataset, and return
             it. If the given sensor ID already exists, the existing sensor is 
             returned instead. To modify a sensor or add a sensor object created 
@@ -383,9 +403,26 @@ class Dataset(Cascading):
             Note that the `sensorId` keyword argument is *not* optional.
             
             :param sensorId: The ID of the new sensor.
-            :keyword name: The new sensor's name
-            :keyword sensorClass: An alternate (sub)class of sensor. Defaults
+            :param name: The new sensor's name
+            :param sensorClass: An alternate (sub)class of sensor. Defaults
                 to `None`, which creates a `Sensor`.
+            :param sourceName: Human-friendly source (authority, network, or
+                other source-of-truth) name for generic/virtual sensor types,
+                particularly 'time' sensors.
+            :param sourceId: Machine-readable, uniquely identifying hash
+                identifying source equivalency for comparing relative
+                sources, particularly 'time' sensors.
+            :param relative: `False` if sensor values are Absolute (default),
+                `True` if values are Relative (have an unknown offset, e.g.,
+                AC-coupled measurements or time values with an unknown
+                Epoch).
+            :param transform: A sensor-level data pre-processing function.
+            :param attributes: A dictionary of arbitrary attributes, e.g.
+                ``Attribute`` elements parsed from the file.
+            :param traceData: An optional dictionary of traceability data,
+                such as sensor serial number, etc.
+            :param bandwidthLimitId: The ID of the bandwidth limit (defined
+                in the ``BwLimitList`` (not currently used).
             :return: The new sensor.
         """
         # `sensorId` is mandatory; it's a keyword argument to streamline import.
@@ -397,8 +434,10 @@ class Dataset(Cascading):
             return self.sensors[sensorId]
         
         sensorClass = Sensor if sensorClass is None else sensorClass
-        sensor = sensorClass(self,sensorId,name=name, transform=transform,
-                             traceData=traceData, attributes=attributes,
+        sensor = sensorClass(self, sensorId, name=name,
+                             sourceName=sourceName, sourceId=sourceId,
+                             relative=relative, traceData=traceData,
+                             transform=transform, attributes=attributes,
                              bandwidthLimitId=bandwidthLimitId)
         self.sensors[sensorId] = sensor
         return sensor
@@ -542,14 +581,19 @@ class Dataset(Cascading):
 #===============================================================================
 
 class Session(object):
-    """ A collection of data within a dataset, e.g. one test run. A Dataset is
-        expected to contain one or more Sessions.
+    """
+    Information about a collection of data within a `Dataset`, e.g. one test run.
+    A `Dataset` is expected to contain at least one `Session`.
     """
     
     def __init__(self, dataset, sessionId=0, startTime=None, endTime=None,
                  utcStartTime=None):
-        """ Constructor. This should generally be done indirectly via
-            `Dataset.addSession()`.
+        """ Information about a collection of data within a :py:class:`Dataset`,
+            i.e., one run of a recorder. A :py:class:`Dataset` loaded from an
+            IDE file contains one `Session`.
+
+            Instantiating a `Session` should generally be done indirectly
+            via :py:meth:`Dataset.addSession()` as part of the import process.
             
             :param dataset: The parent `Dataset`
             :keyword sessionId: The Session's numeric ID. Typically
@@ -561,22 +605,105 @@ class Session(object):
             :keyword utcStartTime: The session's start time, as an absolute
                 POSIX/epoch timestamp.
         """
-        self.dataset = dataset
-        self.startTime = startTime
-        self.endTime = endTime
-        self.sessionId = sessionId
-        self.utcStartTime = utcStartTime or dataset.lastUtcTime
-        
+        self.dataset: Dataset = dataset
+        self.sessionId: int = sessionId
+        self.utcStartTimeOriginal: int = utcStartTime or dataset.lastUtcTime
+        self.utcStartTime: int = self.utcStartTimeOriginal
+
+        self._data: dict[int, 'EventArray'] = None
+        self._offset: float = 0
+
         # firstTime and lastTime are the actual last event time. These will
-        # typically be the same as startTime and endTime, but not necessarily
-        # so.
-        self.firstTime = self.lastTime = None
+        # typically be the same as startTime and endTime, which are being
+        # deprecated.
+        self.firstTimeOriginal: float = startTime
+        self.firstTime: float = startTime
+        self.lastTimeOriginal: float = endTime
+        self.lastTime: float = endTime
+
+        self.syncInfo: Optional[Dict[str, Any]] = None
+        self.syncSensor: Optional[Sensor] = None
+        self.syncZero: float = None
 
 
+    @property
+    def startTime(self) -> float:
+        warnings.warn('Session.startTime is deprecated, and will be removed '
+                      'in the near future. Use Session.firstTime instead. ',
+                      PendingDeprecationWarning)
+        return self.firstTime
+
+
+    # noinspection PyDeprecation
+    @startTime.setter
+    def startTime(self, val: float):
+        warnings.warn('Session.startTime is deprecated, and will be removed '
+                      'in the near future. Use Session.firstTime instead. ',
+                      PendingDeprecationWarning)
+        self.firstTime = val
+
+
+    @property
+    def endTime(self) -> float:
+        warnings.warn('Session.endTime is deprecated, and will be removed '
+                      'in the future. Use Session.lastTime instead. ',
+                      PendingDeprecationWarning)
+        return self.lastTime
+
+
+    # noinspection PyDeprecation
+    @endTime.setter
+    def endTime(self, val: float):
+        warnings.warn('Session.endTime is deprecated, and will be removed '
+                      'in the future. Use Session.lastTime instead. ',
+                      PendingDeprecationWarning)
+        self.lastTime = val
+
+
+    @property
+    def data(self) -> Dict[int, 'EventArray']:
+        """ All the Channel-level `EventArray` instances in this `Session`,
+            keyed by channel ID.
+        """
+        if not self._data or self.dataset.loading:
+            self._data = {}
+            for chid, ch in self.dataset.channels.items():
+                if self.sessionId in ch.sessions:
+                    self._data[chid] = ch.sessions[self.sessionId]
+        return self._data
+
+
+    @property
+    def offset(self) -> float:
+        """ A time offset (in microseconds) for all events, across all
+            Channels, in this `Session`.
+        """
+        return self._offset
+
+
+    @offset.setter
+    def offset(self, offset: float):
+        """ A time offset (in microseconds) for all events, across all
+            Channels, in this `Session`.
+        """
+        offset = offset or 0.
+        self._offset = offset
+        self.firstTime = self.firstTimeOriginal + offset
+        self.lastTime = self.lastTimeOriginal + offset
+        for d in self.data.values():
+            # TODO: Exclude non-relative time channels?
+            d._setOffset(offset)
+
+
+    # noinspection PyDeprecation
     def __repr__(self):
-        return "<%s (id=%s) at 0x%08X>" % (self.__class__.__name__, 
-                                           self.sessionId, id(self))
-    
+        """ Return repr(self). """
+        # TODO: change `utcfromtimestamp(t)` to `fromtimestamp(t, datetime.UTC)`
+        #   after Python 3.10 reaches EoL (2026-10)
+        return "<%s %s (%s)>" % (self.__class__.__name__,
+                                 self.sessionId,
+                                 datetime.utcfromtimestamp(self.utcStartTime))
+
     
     def __eq__(self, other):
         """ x.__eq__(y) <==> x==y """
@@ -586,57 +713,81 @@ class Session(object):
             return False
         else:
             return self.dataset == other.dataset \
-               and self.startTime == other.startTime \
-               and self.endTime == other.endTime \
                and self.sessionId == other.sessionId \
-               and self.utcStartTime == other.utcStartTime \
-               and self.firstTime == other.firstTime \
-               and self.lastTime == other.lastTime
+               and self.utcStartTimeOriginal == other.utcStartTimeOriginal \
+               and self.firstTimeOriginal == other.firstTimeOriginal \
+               and self.lastTimeOriginal == other.lastTimeOriginal
         
 #===============================================================================
 # 
 #===============================================================================
 
+
 class Sensor(Cascading):
     """ One Sensor object. A Dataset contains at least one.
     """
     
-    def __init__(self, dataset, sensorId, name=None, transform=None,
-                  traceData=None, attributes=None, bandwidthLimitId=None):
+    def __init__(self,
+                 dataset: Dataset,
+                 sensorId: Optional[int] = None,
+                 name: Optional[str] = None,
+                 sourceName: Optional[str] = None,
+                 sourceId: Optional[str] = None,
+                 relative: bool = False,
+                 traceData: Optional[Dict[str, Any]] = None,
+                 transform: Union[int, Transform, None] = None,
+                 attributes: Optional[Dict[str, Any]] = None,
+                 bandwidthLimitId: Optional[int] = None):
         """ Constructor. This should generally be done indirectly via
             `Dataset.addSensor()`.
         
-            :param dataset: The parent `Dataset`.
             :param sensorId: The ID of the new sensor.
-            :keyword name: The new sensor's name.
-            :keyword transform: A sensor-level data pre-processing function.
-            :keyword traceData: Sensor traceability data.
-            :keyword attributes: A dictionary of arbitrary attributes, e.g.
+            :param name: The new sensor's name
+            :param sourceName: Human-friendly source (authority, network, or
+                other source-of-truth) name for generic/virtual sensor types,
+                particularly 'time' sensors.
+            :param sourceId: Machine-readable, uniquely identifying hash
+                identifying source equivalency for comparing relative
+                sources, particularly 'time' sensors.
+            :param relative: `False` if sensor values are Absolute (default),
+                `True` if values are Relative (have an unknown offset),
+                e.g., AC-coupled measurements or time values with an unknown
+                Epoch.
+            :param transform: A sensor-level data pre-processing function.
+            :param attributes: A dictionary of arbitrary attributes, e.g.
                 ``Attribute`` elements parsed from the file.
+            :param traceData: An optional dictionary of traceability data,
+                such as sensor serial number, etc.
+            :param bandwidthLimitId: The ID of the bandwidth limit (defined
+                in the ``BwLimitList`` (not currently used).
+            :return: The new sensor.
         """
         if isinstance(name, bytes):
             name.decode()
-        self.name = "Sensor%02d" if name is None else name
+        self.name = f"Sensor{sensorId:02d}" if name is None else name
         self.dataset = dataset
         self.parent = dataset
         self.id = sensorId
-        self.channels = {}
         self.traceData = traceData
         self.attributes = attributes
+        self.sourceName = sourceName
+        self.sourceId = sourceId
+        self.relative = bool(relative)
+
+        self._channels = None
+        self._hash = None
+
+        # Not currently used:
         self.bandwidthLimitId = bandwidthLimitId
         self._bandwidthCutoff = None
         self._bandwidthRolloff = None
+        self._transform = transform
 
 
-    def __getitem__(self, idx):
-        return self.channels[idx]
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.id} '{self.path()}' at 0x{id(self):08x}>"
 
 
-    @property
-    def children(self):
-        return list(self.channels.values())
-
-    
     @property
     def bandwidthCutoff(self):
         if self._bandwidthCutoff is None:
@@ -664,6 +815,15 @@ class Sensor(Cascading):
         return self._bandwidthRolloff
 
 
+    def __hash__(self):
+        if self._hash is None:
+            self._hash = hash((self.name, self.id,
+                               self.sourceName, self.sourceId,
+                               repr(self.traceData), repr(self.attributes),
+                               self.bandwidthLimitId))
+        return self._hash
+
+
     def __eq__(self, other):
         if other is self:
             return True
@@ -671,13 +831,25 @@ class Sensor(Cascading):
             return False
         else:
             return self.name == other.name \
-               and self.dataset == other.dataset \
-               and self.parent == other.parent \
                and self.id == other.id \
-               and self.channels == other.channels \
                and self.traceData == other.traceData \
+               and self.sourceId == other.sourceId \
+               and self.sourceName == other.sourceName \
                and self.attributes == other.attributes \
                and self.bandwidthLimitId == other.bandwidthLimitId
+
+
+    def getReferrers(self) -> List['SubChannel']:
+        """ Get all the `SubChannel` objects that reference this `Sensor`.
+        """
+        if not self._channels or self.dataset.loading:
+            channels = []
+            for ch in self.dataset.channels.values():
+                for subc in ch.subchannels:
+                    if subc.sensor == self or subc.sensor == self.id:
+                        channels.append(subc)
+            self._channels = channels
+        return self._channels
 
 
 #===============================================================================
@@ -739,10 +911,7 @@ class Channel(Transformable):
 
         if isinstance(sensor, int):
             sensor = self.dataset.sensors.get(sensor, None)
-        if sensor is not None:
-            sensor.channels[channelId] = self
-            sensorname = sensor.name
-        
+
         if name is None:
             sensorname = sensor.name if sensor is not None else "Unknown Sensor"
             name = "%s:%02d" % (sensorname, channelId)
@@ -759,7 +928,7 @@ class Channel(Transformable):
         self.hasDisplayRange = displayRange is not None
         
         # Channels have 1 or more subchannels
-        self.subchannels = [None] * len(self.types)
+        self.subchannels: List['SubChannel'] = [None] * len(self.types)
         
         # A set of session EventLists. Populated dynamically with
         # each call to getSession(). 
@@ -778,7 +947,7 @@ class Channel(Transformable):
 
 
     @property
-    def children(self):
+    def children(self) -> List['SubChannel']:
         return list(iter(self))
 
 
@@ -966,6 +1135,8 @@ class Channel(Transformable):
 
 #===============================================================================
 
+
+# noinspection PyMethodOverriding
 class SubChannel(Channel):
     """ Output from a sensor, derived from a channel containing multiple
         pieces of data (e.g. the Y from an accelerometer's XYZ). Looks
@@ -1048,16 +1219,12 @@ class SubChannel(Channel):
         else:
             self.displayName = self.name
 
-        if isinstance(sensorId, int):
-            self.sensor = self.dataset.sensors.get(sensorId, None)
-        elif sensorId is None:
-            if isinstance(parent.sensor, int):
-                self.sensor = self.dataset.sensors.get(parent.sensor, None)
-            else:
-                self.sensor = parent.sensor
-        else:
+        try:
+            sensorId = parent.sensor if sensorId is None else sensorId
+            self.sensor = self.dataset.sensors.get(sensorId, sensorId)
+        except TypeError:
             self.sensor = sensorId
-        
+
         self.types = (parent.types[subchannelId], )
         
         self._sessions = None
@@ -1219,7 +1386,7 @@ class EventArray(Transformable):
         self.dataset = parentChannel.dataset
         self.hasSubchannels = not isinstance(self.parent, SubChannel)
         self._parentList = parentList
-        self._childLists = []
+        self._childLists = []  # TODO: Remove _childLists (seems deprecated)
         
         self.noBivariates = False
 
@@ -1229,29 +1396,37 @@ class EventArray(Transformable):
             self._singleSample = parentChannel.singleSample
 
         if self.hasSubchannels or not isinstance(parentChannel.parent, Channel):
-            # Cache of block start times and sample indices for faster search
+            # Cache of block start times and sample indices for faster search.
+            # Note: _blockTimes is not changed if a time offset is applied.
             self._blockTimes = []
             self._blockIndices = []
+            self._blockIndicesArray = np.array([], dtype=np.int64)
+            self._blockTimesArray = np.array([], dtype=np.float64)
         else:
             s = self.session.sessionId if session is not None else None
             ps = parentChannel.parent.getSession(s)
             self._blockTimes = ps._blockTimes
             self._blockIndices = ps._blockIndices
+            self._blockIndicesArray = ps._blockIndicesArray
+            self._blockTimesArray = ps._blockTimesArray
 
             self.noBivariates = ps.noBivariates
-        
+
         if self.hasSubchannels:
             self.channelId = self.parent.id
             self.subchannelId = None
+            self.parseBlock = self.parent.parseBlock
         else:
             self.channelId = self.parent.parent.id
             self.subchannelId = self.parent.id
-        
+            self.parseBlock = self.parent.parent.parseBlock
+
         self._hasSubsamples = False
         
         self.hasDisplayRange = self.parent.hasDisplayRange
         self.displayRange = self.parent.displayRange
 
+        self._mean = None
         self.removeMean = False
         self.hasMinMeanMax = True
         self._rollingMeanSpan = None
@@ -1262,16 +1437,24 @@ class EventArray(Transformable):
         self.updateTransforms(recurse=False)
         self.allowMeanRemoval = parentChannel.allowMeanRemoval    
 
-        if self.hasSubchannels:
-            self.parseBlock = self.parent.parseBlock
-        else:
-            self.parseBlock = self.parent.parent.parseBlock
+        self._npType = np.uint8
+        self._makeDType()
 
-        self._blockIndicesArray = np.array([], dtype=np.float64)
-        self._blockTimesArray = np.array([], dtype=np.float64)
+        self._channelDataLock = parentChannel.dataset._channelDataLock
+        self._cacheArray = None
+        self._cacheBytes = None
 
-        self._mean = None
+        # TODO: These seem to be unused; remove?
+        # self._fullyCached = False
+        # self._cacheStart = None
+        # self._cacheEnd = None
+        # self._cacheBlockStart = None
+        # self._cacheBlockEnd = None
+        # # self._cacheLen = 0
 
+
+    def _makeDType(self):
+        """ Construct the Numpy type for the channel's payload. """
         _format = self.parent.parser.format
         if not _format:
             self._npType = np.uint8
@@ -1281,7 +1464,7 @@ class EventArray(Transformable):
             if isinstance(_format, bytes):
                 _format = _format.decode()
 
-            if _format[0] in ['<', '>', '=']:
+            if _format[0] in '<>=':
                 endian = _format[0]
                 dtypes = [endian + ChannelDataBlock.TO_NP_TYPESTR[x] for x in _format[1:]]
             else:
@@ -1289,15 +1472,17 @@ class EventArray(Transformable):
 
             self._npType = np.dtype([(str(i), dtype) for i, dtype in enumerate(dtypes)])
 
-        self._channelDataLock = parentChannel.dataset._channelDataLock
-        self._cacheArray = None
-        self._cacheBytes = None
-        self._fullyCached = False
-        self._cacheStart = None
-        self._cacheEnd = None
-        self._cacheBlockStart = None
-        self._cacheBlockEnd = None
-        self._cacheLen = 0
+
+    def _setOffset(self, offset):
+        """ Apply an offset to the `EventArray` timestamps. Do not use
+            directly; use `Session.offset`.
+        """
+        for d in self._data:
+            d.startTime = d.startTimeOriginal + offset
+            d.endTime = d.endTimeOriginal + offset
+
+        # XXX: Can probably skip this if the dataset is loading
+        self._blockTimesArray = np.array(self._blockTimes, dtype=np.float64) + offset
 
 
     @property
@@ -1331,7 +1516,7 @@ class EventArray(Transformable):
                 sessionId = self.session.sessionId if self.session is not None else None
                 children = []
                 dispX = []
-                for x,sc in zip(xs,self.parent.subchannels):
+                for x, sc in zip(xs, self.parent.subchannels):
                     if sessionId in sc.sessions:
                         cl = sc.sessions[sessionId]
                         if cl.transform is None:
@@ -1386,11 +1571,11 @@ class EventArray(Transformable):
         newList._channelDataLock = self._channelDataLock
         newList._cacheArray = self._cacheArray
         newList._cacheBytes = self._cacheBytes
-        newList._fullyCached = self._fullyCached
-        newList._cacheStart = self._cacheStart
-        newList._cacheEnd = self._cacheEnd
-        newList._cacheBlockStart = self._cacheBlockStart
-        newList._cacheBlockEnd = self._cacheBlockEnd
+        # newList._fullyCached = self._fullyCached
+        # newList._cacheStart = self._cacheStart
+        # newList._cacheEnd = self._cacheEnd
+        # newList._cacheBlockStart = self._cacheBlockStart
+        # newList._cacheBlockEnd = self._cacheBlockEnd
         return newList
     
 
@@ -1409,14 +1594,19 @@ class EventArray(Transformable):
             # Set the session first/last times if they aren't already set.
             # Possibly redundant if all sessions are 'closed.'
             if self.session.firstTime is None:
-                self.session.firstTime = block.startTime
+                self.session.firstTimeOriginal = block.startTime
+                self.session.firstTime = block.startTime + self.session._offset
             else:
-                self.session.firstTime = min(self.session.firstTime, block.startTime)
+                self.session.firstTimeOriginal = min(self.session.firstTimeOriginal, block.startTime)
+                self.session.firstTime = self.session.firstTimeOriginal + self.session._offset
 
             if self.session.lastTime is None:
-                self.session.lastTime = block.endTime
+                self.session.lastTimeOriginal = block.endTime
+                self.session.lastTime = block.endTime + self.session._offset
             else:
-                self.session.lastTime = max(self.session.lastTime, block.endTime)
+                self.session.lastTimeOriginal = max(self.session.lastTimeOriginal, block.endTime)
+                self.session.lastTime = self.session.lastTimeOriginal + self.session._offset
+
 
             # Check that the block actually contains at least one sample.
             if block.numSamples < 1:
@@ -1446,7 +1636,7 @@ class EventArray(Transformable):
             # HACK (somewhat): Single-sample-per-block channels get min/mean/max
             # which is just the same as the value of the sample. Set the values,
             # but don't set hasMinMeanMax.
-            if self._singleSample is True:# and not self.hasMinMeanMax:
+            if self._singleSample is True:  # and not self.hasMinMeanMax:
                 block.minMeanMax = np.tile(block.payload, 3)
                 mmmArr = np_recfunctions.structured_to_unstructured(
                         block._minMeanMax.view(self._npType))
@@ -1461,7 +1651,7 @@ class EventArray(Transformable):
                 # XXX: Attempt to calculate min/mean/max here instead of
                 #  in _computeMinMeanMax(). Causes issues with pressure for some
                 #  reason - it starts removing mean and won't plot.
-                vals = np_recfunctions.structured_to_unstructured(block.payload.view(self._npType))
+                vals: np.array = np_recfunctions.structured_to_unstructured(block.payload.view(self._npType))
                 block.min = vals.min(axis=0)
                 block.mean = vals.mean(axis=0)
                 block.max = vals.max(axis=0)
@@ -1519,7 +1709,7 @@ class EventArray(Transformable):
 
         '''
         if len(self._blockIndicesArray) != len(self._blockIndices):
-            self._blockIndicesArray = np.array(self._blockIndices)
+            self._blockIndicesArray = np.array(self._blockIndices, dtype=np.int64)
 
         idxOffset = max(start, 1)
         return idxOffset-1 + np.searchsorted(
@@ -1534,7 +1724,8 @@ class EventArray(Transformable):
             :keyword start: The first block index to search
             :keyword stop: The last block index to search
         """
-        # TODO: profile & determine if this change is beneficial
+        # TODO: profile & determine if this change is beneficial. I'm not
+        #  sure the new version was ever actually profiled vs. the old.
         '''
         if stop:
             blockIdx = bisect_right(self._blockTimes, t, start, stop)
@@ -1545,7 +1736,12 @@ class EventArray(Transformable):
         return blockIdx
         '''
         if len(self._blockTimesArray) != len(self._blockTimes):
-            self._blockTimesArray = np.array(self._blockTimes)
+            self._blockTimesArray = np.array(self._blockTimes, dtype=np.float64) + self.session._offset
+
+        if t is None or t < self._blockTimesArray[0]:
+            return 0
+        elif t > self._blockTimesArray[-1]:
+            return len(self._blockTimesArray)
 
         idxOffset = max(start, 1)
         return idxOffset-1 + np.searchsorted(
@@ -1570,8 +1766,8 @@ class EventArray(Transformable):
         span = self.rollingMeanSpan
         
         if (block._rollingMean is not None 
-            and block._rollingMeanSpan == span 
-            and block._rollingMeanLen == len(self._data)):
+                and block._rollingMeanSpan == span
+                and block._rollingMeanLen == len(self._data)):
             return block._rollingMean
 
         self._computeMinMeanMax()
@@ -1654,7 +1850,6 @@ class EventArray(Transformable):
             xform = self._fullXform
 
         if isinstance(idx, (int, np.integer)):
-
 
             if idx >= len(self):
                 raise IndexError("EventArray index out of range")
@@ -1786,9 +1981,11 @@ class EventArray(Transformable):
             out = np.empty((len(rawData.dtype), len(rawData)))
 
         if isinstance(self.parent, SubChannel):
-            xform.polys[self.subchannelId].inplace(rawData, out=out, noBivariates=self.noBivariates)
+            xform.polys[self.subchannelId].inplace(rawData, out=out,
+                                                   noBivariates=self.noBivariates)
         else:
-            xform.inplace(np_recfunctions.structured_to_unstructured(rawData).T, out=out, noBivariates=self.noBivariates)
+            xform.inplace(np_recfunctions.structured_to_unstructured(rawData).T,
+                          out=out, noBivariates=self.noBivariates)
 
         if self.removeMean:
             out[1:] -= out[1:].mean(axis=1, keepdims=True)
@@ -1852,9 +2049,11 @@ class EventArray(Transformable):
         self._inplaceTime(start, end, step, out=out[0])
 
         if isinstance(self.parent, SubChannel):
-            xform.polys[self.subchannelId].inplace(rawData, out=out[1], timestamp=out[0], noBivariates=self.noBivariates)
+            xform.polys[self.subchannelId].inplace(rawData, out=out[1], timestamp=out[0],
+                                                   noBivariates=self.noBivariates)
         else:
-            xform.inplace(np_recfunctions.structured_to_unstructured(rawData).T, out=out[1:], timestamp=out[0], noBivariates=self.noBivariates)
+            xform.inplace(np_recfunctions.structured_to_unstructured(rawData).T,
+                          out=out[1:], timestamp=out[0], noBivariates=self.noBivariates)
 
         if self.removeMean:
             out[1:] -= out[1:].mean(axis=1, keepdims=True)
@@ -1882,7 +2081,8 @@ class EventArray(Transformable):
 
         self._computeMinMeanMax()
 
-        data = self.arrayJitterySlice(start=start, end=end, step=step, jitter=jitter, display=display)
+        data = self.arrayJitterySlice(start=start, end=end, step=step,
+                                      jitter=jitter, display=display)
 
         yield from data.T
         
@@ -1954,10 +2154,12 @@ class EventArray(Transformable):
 
         noBivariates = self.noBivariates
         if isinstance(self.parent, SubChannel):
-            xform.polys[self.subchannelId].inplace(rawData, out=out[1], timestamp=out[0], noBivariates=noBivariates)
+            xform.polys[self.subchannelId].inplace(rawData, out=out[1], timestamp=out[0],
+                                                   noBivariates=noBivariates)
         else:
             for i, (k, _) in enumerate(rawData.dtype.descr):
-                xform.polys[i].inplace(rawData[k], out=out[i + 1], timestamp=out[0], noBivariates=noBivariates)
+                xform.polys[i].inplace(rawData[k], out=out[i + 1], timestamp=out[0],
+                                       noBivariates=noBivariates)
 
         return out
 
@@ -2140,8 +2342,7 @@ class EventArray(Transformable):
         session = self.session
         removeMean = self.removeMean and self.allowMeanRemoval
         _getBlockRollingMean = self._getBlockRollingMean
-        if not hasSubchannels:
-            parent_id = self.subchannelId
+        parent_id = None if self.hasSubchannels else self.subchannelId
 
         if self.useAllTransforms:
             xform = self._fullXform
@@ -2538,14 +2739,14 @@ class EventArray(Transformable):
                 return first
             if outOfRange:
                 return first
-            raise IndexError("Specified time occurs before first event (%d)" % first[0])
+            raise IndexError("Specified time occurs before first event (%s)" % first[0])
         elif startIdx >= len(self) - 1:
             last = self.__getitem__(-1, display=display)
             if last[0] == at:
                 return last
             if outOfRange:
                 return last
-            raise IndexError("Specified time occurs after last event (%d)" % last[0])
+            raise IndexError("Specified time occurs after last event (%s)" % last[0])
         
         startEvt = self.__getitem__(startIdx, display=display)
         endEvt = self.__getitem__(startIdx+1, display=display)
@@ -2672,6 +2873,7 @@ class EventArray(Transformable):
         return self.arraySlice(startIdx, stopIdx, step, display=display)
 
 
+    # noinspection PyDeprecation
     def exportCsv(self, stream, start=None, stop=None, step=1, subchannels=True,
                   callback=None, callbackInterval=0.01, timeScalar=1,
                   raiseExceptions=False, dataFormat="%.6f", delimiter=", ",
@@ -2717,7 +2919,8 @@ class EventArray(Transformable):
                 transform (e.g. unit conversion).
             :return: Tuple: The number of rows exported and the elapsed time.
         """
-        noCallback = callback is None
+        # TODO: change `utcfromtimestamp(t)` to `fromtimestamp(t, datetime.UTC)`
+        #   after Python 3.10 reaches EoL (2026-10)
         _self = self.copy()
 
         if noBivariates is not None:
@@ -2861,8 +3064,8 @@ class EventArray(Transformable):
     def _inplaceTimeFromIndices(self, indices, out=None):
         if out is None:
             out = indices.astype(np.float64)
-
-        out[:] = indices
+        else:
+            out[:] = indices
 
         arrayStart = float(self._data[0].startTime)
         arrayEnd = float(self._data[-1].endTime)

--- a/idelib/importer.py
+++ b/idelib/importer.py
@@ -4,10 +4,9 @@
 
 from collections import Counter
 from datetime import datetime
+import hashlib
 import os.path
 import sys
-from time import time as time_time
-from time import sleep
 import warnings
 
 import struct
@@ -28,8 +27,7 @@ from . import parsers
 # from dataset import __DEBUG__
 
 import logging
-logger = logging.getLogger('idelib')
-logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 
 #===============================================================================
@@ -379,7 +377,8 @@ def openFile(stream, updater=None, parserTypes=None, defaults=None, name=None,
 
     if doc._parsers is None:
         doc._parsers = instantiateParsers(doc, parserTypes)
-    
+
+    fingerprint = hashlib.md5()
     elementParsers = doc._parsers
     
     try:
@@ -392,6 +391,7 @@ def openFile(stream, updater=None, parserTypes=None, defaults=None, name=None,
             parser = elementParsers[r.name]
             if parser.makesData():
                 break
+            fingerprint.update(r.getRaw())
             parser.parse(r) 
             
     except IOError as e:
@@ -412,7 +412,8 @@ def openFile(stream, updater=None, parserTypes=None, defaults=None, name=None,
         # Got data before the recording props; use defaults.
         if defaults is not None:
             createDefaultSensors(doc, defaults)
-            
+
+    doc._fingerprint = fingerprint
     doc.updateTransforms()
     return doc
 

--- a/idelib/matfile.py
+++ b/idelib/matfile.py
@@ -9,8 +9,8 @@ import string
 import struct
 
 import logging
-logger = logging.getLogger('idelib')
-logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
 
 # NOTE: 64 bit Scipy is unstable; avoid using it for now (v0.13.2, 12/2014).
 # from scipy.io.matlab import mio5_params as MP

--- a/idelib/parsers.py
+++ b/idelib/parsers.py
@@ -729,9 +729,6 @@ class SimpleChannelDataBlockParser(ElementHandler):
         if block.endTime is not None:
             block.endTime = timeOffset + int(self.fixOverflow(block, block.endTime))
 
-        block.startTimeOriginal = block.startTime
-        block.endTimeOriginal = block.endTime
-
         if channel not in self.doc.channels:
             # Unknown channel; could be debugging info, so that might be okay.
             # FUTURE: Better handling of unknown channel types. Low priority.
@@ -806,11 +803,6 @@ class ChannelDataBlock(BaseDataBlock):
         # the end timestamp; if it's missing, duplicate the starting time.
         if self.endTime is None:
             self.endTime = self.startTime
-
-        # Original start/end times, so `startTime`/`endTime` can be modified
-        # for syncing and reverted. Also, some functions need the originals.
-        self.startTimeOriginal = self.startTime
-        self.endTimeOriginal = self.endTime
 
         self._payload = None
         self._parser = None

--- a/idelib/parsers.py
+++ b/idelib/parsers.py
@@ -47,15 +47,8 @@ import numpy as np
 from . import transforms
 from .attributes import decode_attributes
 
-# Dictionaries in Python 3.7+ are explicitly insert-ordered in all
-# implementations. If older, continue to use `collections.OrderedDict`.
-if sys.hexversion < 0x03070000:
-    from collections import OrderedDict as Dict
-else:
-    Dict = dict
-
 import logging
-logger = logging.getLogger('idelib')
+logger = logging.getLogger(__name__)
 logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
 
 #===============================================================================
@@ -108,7 +101,7 @@ def renameKeys(d, renamed, exclude=True, recurse=True,
     elif not isinstance(d, dict):
         return d
     
-    result = Dict()
+    result = {}
 
     for oldname, v in d.items():
         if oldname == "Attribute":
@@ -180,7 +173,7 @@ def parseAttribute(obj, element, multiple=True):
             the last `Attribute` element parsed. 
     """
     if not hasattr(obj, 'attributes'):
-        obj.attributes = Dict()
+        obj.attributes = {}
         
     k = v = None
     for ch in element.value:
@@ -731,15 +724,18 @@ class SimpleChannelDataBlockParser(ElementHandler):
             # TODO: Actually handle, instead of ignoring?
             logger.warning("XXX: bad attribute in element %s" % element)
             return 0
-            
-        
+
         block.startTime = timeOffset + int(self.fixOverflow(block, timestamp))
         if block.endTime is not None:
             block.endTime = timeOffset + int(self.fixOverflow(block, block.endTime))
 
+        block.startTimeOriginal = block.startTime
+        block.endTimeOriginal = block.endTime
+
         if channel not in self.doc.channels:
             # Unknown channel; could be debugging info, so that might be okay.
             # FUTURE: Better handling of unknown channel types. Low priority.
+            logger.debug(f'Got ChannelDataBlock for unknown channel ID: {channel}')
             return 0
 
         try:
@@ -793,11 +789,11 @@ class ChannelDataBlock(BaseDataBlock):
                 parseAttribute(self, el)
                 el.gc()
             elif el.name == "StartTimeCodeAbs":
-                # TODO: store indicator that the start timestamp is non-modulo?
+                # FUTURE: store indicator that the start timestamp is non-modulo?
                 self.startTime = el.value
                 self._timestamp = el.value
             elif el.name == "EndTimeCodeAbs":
-                # TODO: store indicator that the end timestamp is non-modulo?
+                # FUTURE: store indicator that the end timestamp is non-modulo?
                 self.endTime = el.value
             elif el.name == "ChannelFlags":
                 # FUTURE: Handle channel flag bits
@@ -805,17 +801,23 @@ class ChannelDataBlock(BaseDataBlock):
             # Add other child element handlers here.
         
         element.gc(recurse=False)
-        
+
         # Single-sample blocks have a total time of 0. Old files did not write
         # the end timestamp; if it's missing, duplicate the starting time.
         if self.endTime is None:
             self.endTime = self.startTime
 
-        self._payload = None
+        # Original start/end times, so `startTime`/`endTime` can be modified
+        # for syncing and reverted. Also, some functions need the originals.
+        self.startTimeOriginal = self.startTime
+        self.endTimeOriginal = self.endTime
 
+        self._payload = None
         self._parser = None
-        self._streamDtype = None
-        self._commonDtype = None
+
+        # TODO: These don't seem to be used. Remove?
+        # self._streamDtype = None
+        # self._commonDtype = None
 
     @property
     def payload(self):
@@ -1008,7 +1010,10 @@ class SensorListParser(ElementHandler):
         "TraceabilityData": "traceData",
         "SensorSerialNumber": "serialNum",
         "Attribute": "attributes",
-#         "SensorBwLimitIDRef": "bandwidthLimitId" # FUTURE
+        "SourceName": "sourceName",
+        "SourceIdentifier": "sourceId",
+        "IsRelative": "relative",
+        "SensorBwLimitIDRef": "bandwidthLimitId"
     }
     
     def parse(self, element, **kwargs):
@@ -1280,6 +1285,7 @@ class TimeBaseUTCParser(ElementHandler):
         val = element.value
         self.doc.lastUtcTime = val
         self.doc.lastSession.utcStartTime = val
+        self.doc.lastSession.utcStartTimeOriginal = val
 
 
 class RecorderUserDataParser(ElementHandler):

--- a/idelib/schemata/mide_ide.xml
+++ b/idelib/schemata/mide_ide.xml
@@ -427,24 +427,6 @@
                 <BinaryElement name="AnnotationStyle" id="0x10200026" multiple="0" mandatory="0" /> Application-specific data describing the visual representation of the annotation.
             </MasterElement>
         </MasterElement>
-        <MasterElement name="SyncInfo" id="0x10200031" multiple="0" mandatory="0">
-            Information connecting this recording to another for the purpose of synchronizing data.
-            <UIntegerElement name="SyncActive" id="0x10200032" multiple="0" mandatory="0" default="1"> 1 (or no element) if this sync is applied, 0 if inactive. Only one SyncInfo should be marked as active; If multiple SyncInfo are marked as active, only the first is applied. </UIntegerElement>
-            <UIntegerElement name="SyncChannelIDRef" id="0x10200033" multiple="0" mandatory="0"> The Channel ID of the time sync reference. </UIntegerElement>
-            <UIntegerElement name="SyncSubChannelIDRef" id="0x10200034" multiple="0" mandatory="0"> The SubChannel ID of the time sync reference. </UIntegerElement>
-            <UIntegerElement name="SyncSessionIDRef" id="0x1020003B" multiple="0" mandatory="0"> The SubChannel ID of the time sync reference. </UIntegerElement>
-            <UnicodeElement name="SyncSourceName" id="0x10200035" multiple="0"> Human-friendly source (authority, network, or other source-of-truth) name for generic/virtual 'time' sensors. </UnicodeElement>
-            <StringElement name="SyncSourceIdentifier" id="0x10200036" multiple="0" minver="4"> Machine-readable, uniquely identifying hash identifying source equivalency for comparing 'time' sensors. </StringElement>
-            <IntegerElement name="SyncReferenceZero" id="0x10200037" multiple="0" mandatory="0"> The time reference value corresponding to this file's timestamp zero. </IntegerElement>
-            <IntegerElement name="SyncZero" id="0x10200038" multiple="0" mandatory="0"> The time reference value corresponding to the reference file's timestamp zero. </IntegerElement>
-            <FloatElement name="SyncClockDrift" id="0x10200039" multiple="0" mandatory="0"> The rate, in microseconds per microsecond, that the enDAQ timestamps drift from the sync reference time. </FloatElement>
-            <UnicodeElement name="SyncReferenceFilename" id="0x1020003A" multiple="0" mandatory="0"> The file to which this file is synced. </UnicodeElement>
-            <StringElement name="SyncReferenceFingerprint" id="0x1020003C" multiple="0" mandatory="0"> The fingerprint hash of the reference file to which this file is synced (a hex string). </StringElement>
-            <UnicodeElement name="SyncFilename" id="0x1020003D" multiple="0" mandatory="0"> This file's original name. Used when transferring sync data. </UnicodeElement>
-            <StringElement name="SyncFingerprint" id="0x1020003E" multiple="0" mandatory="0"> This file's fingerprint hash (a hex string). Used when transferring sync data. </StringElement>
-            <UIntegerElement name="SyncTimeBaseUTC"  id="0x10205462"> The reference's UTC starting time, applied to the synched Dataset. </UIntegerElement>
-            <UIntegerElement name="TimeBaseUTC"  id="0x5462" /> <!-- Reused. The Dataset's original starting time, for transferring sync data. -->
-        </MasterElement>
         <BinaryElement name="WindowLayout" id="0x10200011" multiple="0" mandatory="0"> Application-specific data describing GUI settings, etc. </BinaryElement>
 
         <!-- Reused existing elements, which override those in the RecordingProperties, etc. -->

--- a/idelib/schemata/mide_ide.xml
+++ b/idelib/schemata/mide_ide.xml
@@ -414,10 +414,12 @@
 
     <!-- User-supplied metadata -->
     <MasterElement name="UserData" id="0x10200000" multiple="0" mandatory="0">
+        A block of user-supplied data, appended to a file after recording, used primarily to keep information about the recording's display.
         <IntegerElement name="TimebaseOffset" id="0x10200010" multiple="0" mandatory="0"> An offset (in microseconds) for all sample times. </IntegerElement>
-        <BinaryElement name="WindowLayout" id="0x10200011" multiple="0" mandatory="0"> Application-specific data describing GUI settings, etc. </BinaryElement>
-        <MasterElement name="AnnotationList" id="0x10200020" multiple="0" mandatory="0"> User-created highlights, marking particular spans and points in time
+        <MasterElement name="AnnotationList" id="0x10200020" multiple="0" mandatory="0">
+            User-created highlights, marking particular spans and points in time
             <MasterElement name="Annotation" id="0x10200021" multiple="1" mandatory="0">
+                One user-created marker, indicating a point or range in time.
                 <UIntegerElement name="AnnotationID" id="0x10200022" multiple="0" mandatory="1" /> The annotation's ID, arbitrary but unique to the file.
                 <UnicodeElement name="AnnotationText" id="0x10200023" multiple="0" mandatory="0" /> A name and/or notes about the annotation.
                 <IntegerElement name="AnnotationStartTime" id="0x10200024" multiple="0" mandatory="1" /> Annotation start time.
@@ -425,8 +427,28 @@
                 <BinaryElement name="AnnotationStyle" id="0x10200026" multiple="0" mandatory="0" /> Application-specific data describing the visual representation of the annotation.
             </MasterElement>
         </MasterElement>
+        <MasterElement name="SyncInfo" id="0x10200031" multiple="0" mandatory="0">
+            Information connecting this recording to another for the purpose of synchronizing data.
+            <UIntegerElement name="SyncActive" id="0x10200032" multiple="0" mandatory="0" default="1"> 1 (or no element) if this sync is applied, 0 if inactive. Only one SyncInfo should be marked as active; If multiple SyncInfo are marked as active, only the first is applied. </UIntegerElement>
+            <UIntegerElement name="SyncChannelIDRef" id="0x10200033" multiple="0" mandatory="0"> The Channel ID of the time sync reference. </UIntegerElement>
+            <UIntegerElement name="SyncSubChannelIDRef" id="0x10200034" multiple="0" mandatory="0"> The SubChannel ID of the time sync reference. </UIntegerElement>
+            <UIntegerElement name="SyncSessionIDRef" id="0x1020003B" multiple="0" mandatory="0"> The SubChannel ID of the time sync reference. </UIntegerElement>
+            <UnicodeElement name="SyncSourceName" id="0x10200035" multiple="0"> Human-friendly source (authority, network, or other source-of-truth) name for generic/virtual 'time' sensors. </UnicodeElement>
+            <StringElement name="SyncSourceIdentifier" id="0x10200036" multiple="0" minver="4"> Machine-readable, uniquely identifying hash identifying source equivalency for comparing 'time' sensors. </StringElement>
+            <IntegerElement name="SyncReferenceZero" id="0x10200037" multiple="0" mandatory="0"> The time reference value corresponding to this file's timestamp zero. </IntegerElement>
+            <IntegerElement name="SyncZero" id="0x10200038" multiple="0" mandatory="0"> The time reference value corresponding to the reference file's timestamp zero. </IntegerElement>
+            <FloatElement name="SyncClockDrift" id="0x10200039" multiple="0" mandatory="0"> The rate, in microseconds per microsecond, that the enDAQ timestamps drift from the sync reference time. </FloatElement>
+            <UnicodeElement name="SyncReferenceFilename" id="0x1020003A" multiple="0" mandatory="0"> The file to which this file is synced. </UnicodeElement>
+            <StringElement name="SyncReferenceFingerprint" id="0x1020003C" multiple="0" mandatory="0"> The fingerprint hash of the reference file to which this file is synced (a hex string). </StringElement>
+            <UnicodeElement name="SyncFilename" id="0x1020003D" multiple="0" mandatory="0"> This file's original name. Used when transferring sync data. </UnicodeElement>
+            <StringElement name="SyncFingerprint" id="0x1020003E" multiple="0" mandatory="0"> This file's fingerprint hash (a hex string). Used when transferring sync data. </StringElement>
+            <UIntegerElement name="SyncTimeBaseUTC"  id="0x10205462"> The reference's UTC starting time, applied to the synched Dataset. </UIntegerElement>
+            <UIntegerElement name="TimeBaseUTC"  id="0x5462" /> <!-- Reused. The Dataset's original starting time, for transferring sync data. -->
+        </MasterElement>
+        <BinaryElement name="WindowLayout" id="0x10200011" multiple="0" mandatory="0"> Application-specific data describing GUI settings, etc. </BinaryElement>
 
         <!-- Reused existing elements, which override those in the RecordingProperties, etc. -->
+        <!-- Not currently in use by idelib or enDAQ Lab -->
         <UIntegerElement name="TimeBaseUTC"  id="0x5462" />
         <MasterElement name="CalibrationList" id="0x4B00" />
         <MasterElement name="WarningList" id="0x5360" />

--- a/idelib/transforms.py
+++ b/idelib/transforms.py
@@ -25,8 +25,7 @@ if sys.hexversion < 0x03070000:
 else:
     Dict = dict
 
-logger = logging.getLogger('idelib')
-logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 
 #===============================================================================

--- a/idelib/userdata.py
+++ b/idelib/userdata.py
@@ -4,12 +4,15 @@ of IDE files. This data is intended primarily to retain user preferences for
 the display of the `Dataset`.
 """
 
+import copy
 import errno
 import os.path
 import logging
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union, TYPE_CHECKING
 
-from .dataset import Dataset
+if TYPE_CHECKING:
+    # codecov:ignore:next
+    from .dataset import Dataset
 
 #===============================================================================
 #
@@ -17,13 +20,14 @@ from .dataset import Dataset
 
 MIN_VOID_SIZE = 9
 
-logger = logging.getLogger('idelib')
+logger = logging.getLogger(__name__)
+
 
 #===============================================================================
 #
 #===============================================================================
 
-def getUserDataPos(dataset: Dataset,
+def getUserDataPos(dataset: "Dataset",
                    refresh: bool = False) -> Tuple[bool, int, int]:
     """ Get the offset of the start of the user data.
 
@@ -69,8 +73,9 @@ def getUserDataPos(dataset: Dataset,
     finally:
         fs.seek(oldpos, os.SEEK_SET)
 
-    dataset._userdataOffset = offset
-    dataset._filesize = filesize
+        dataset._userdataOffset = offset
+        dataset._filesize = filesize
+
     return hasdata, offset, filesize
 
 
@@ -78,7 +83,7 @@ def getUserDataPos(dataset: Dataset,
 #
 #===============================================================================
 
-def readUserData(dataset: Dataset,
+def readUserData(dataset: "Dataset",
                  refresh: bool = False) -> Union[Dict[str, Any], None]:
     """ Read application-specific user data from the end of an IDE file.
 
@@ -107,17 +112,19 @@ def readUserData(dataset: Dataset,
         data, _next = doc.parseElement(fs)
         dump = data.dump()
         dataset._userdata = dump
-        return dump
 
     finally:
         fs.seek(oldpos, os.SEEK_SET)
+
+    dataset._userdataOriginal = copy.deepcopy(dataset._userdata)
+    return dataset._userdata
 
 
 #===============================================================================
 #
 #===============================================================================
 
-def writeUserData(dataset: Dataset,
+def writeUserData(dataset: "Dataset",
                   userdata: Dict[str, Any],
                   refresh: bool = False):
     """ Write user data to the end of an IDE file.
@@ -183,6 +190,7 @@ def writeUserData(dataset: Dataset,
             fs.write(userblob)
 
         dataset._userdata = userdata
+        dataset._userdataOriginal = copy.deepcopy(dataset._userdata)
         logger.debug(f'(userdata) Wrote {len(userblob)} bytes to {dataset} '
                      f'(file was {filesize}, now {newsize})')
 

--- a/idelib/util.py
+++ b/idelib/util.py
@@ -4,7 +4,6 @@ Utility functions for doing low-level, general-purpose EBML reading and writing.
 
 from io import IOBase
 import logging
-import os.path
 from pathlib import Path
 
 from ebmlite import loadSchema
@@ -16,7 +15,7 @@ from .dataset import Dataset
 #
 # ==============================================================================
 
-logger = logging.getLogger('idelib')
+logger = logging.getLogger(__name__)
 
 
 # ==============================================================================

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -564,7 +564,6 @@ class TestSession(unittest.TestCase):
 
     def testInitAndEQ(self):
         self.dataset = importer.importFile('./testing/SSX70065.IDE')
-        # TODO: Change these Sessions, they aren't realistic.
         session1 = Session(
             self.dataset, sessionId=1, startTime=2, endTime=3, utcStartTime=4)
         session2 = Session(
@@ -574,9 +573,9 @@ class TestSession(unittest.TestCase):
         self.assertNotEqual(session1, GenericObject())
 
         self.assertEqual(session1.dataset, self.dataset)
+        self.assertEqual(session1.endTime, 3)
         self.assertEqual(session1.sessionId, 1)
-        self.assertEqual(session1.firstTime, 2)
-        self.assertEqual(session1.lastTime, 3)
+        self.assertEqual(session1.startTime, 2)
         self.assertEqual(session1.utcStartTime, 4)
 
 

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -441,15 +441,10 @@ class TestDataset(unittest.TestCase):
     def testAddSensor(self):
         """ Test that the sensors are being added correctly. """
         sensor1 = Sensor(self.dataset, 0)
-        sensor2 = Sensor(self.dataset, 'q')
 
         # test that numeric ids work
         self.dataset.addSensor(0)
         self.assertEqual(sensor1, self.dataset.sensors[0])
-
-        # test that string ids work
-        self.dataset.addSensor('q')
-        self.assertEqual(sensor2, self.dataset.sensors['q'])
 
 
     def testAddChannel(self):
@@ -481,16 +476,12 @@ class TestDataset(unittest.TestCase):
         # set up new transforms
         xform1 = Transformable()
         xform1.id = 1
-        xform2 = Transformable()
-        xform2.id = 'q'
         xform3 = Transformable()
         xform3.id = None
 
         # assert that transforms are being added correctly
         self.dataset.addTransform(xform1)
-        self.dataset.addTransform(xform2)
         self.assertEqual(self.dataset.transforms[1], xform1)
-        self.assertEqual(self.dataset.transforms['q'], xform2)
 
         # assert that transforms without an id will raise errors
         self.assertRaises(ValueError, self.dataset.addTransform, xform3)
@@ -573,6 +564,7 @@ class TestSession(unittest.TestCase):
 
     def testInitAndEQ(self):
         self.dataset = importer.importFile('./testing/SSX70065.IDE')
+        # TODO: Change these Sessions, they aren't realistic.
         session1 = Session(
             self.dataset, sessionId=1, startTime=2, endTime=3, utcStartTime=4)
         session2 = Session(
@@ -582,19 +574,20 @@ class TestSession(unittest.TestCase):
         self.assertNotEqual(session1, GenericObject())
 
         self.assertEqual(session1.dataset, self.dataset)
-        self.assertEqual(session1.endTime, 3)
         self.assertEqual(session1.sessionId, 1)
-        self.assertEqual(session1.startTime, 2)
+        self.assertEqual(session1.firstTime, 2)
+        self.assertEqual(session1.lastTime, 3)
         self.assertEqual(session1.utcStartTime, 4)
 
 
     def testRepr(self):
         """ Test that __repr__ is creating the correct string. """
+        # TODO: Not realistic. Redo or remove this test.
         fileStream = makeStreamLike('./testing/SSX70065.IDE')
         dataset = Dataset(fileStream)
         session1 = Session(
             dataset, sessionId=1, startTime=2, endTime=3, utcStartTime=4)
-        self.assertIn("<Session (id=1) at", repr(session1))
+        self.assertIn("<Session 1 (", repr(session1))
 
 
 #===============================================================================
@@ -626,23 +619,10 @@ class TestSensor(unittest.TestCase):
         self.assertEqual(self.sensor1, Sensor(self.dataset, 1))
 
         sensor3 = Sensor(self.dataset, 3, name=None)
-        self.assertEqual(sensor3.name, "Sensor%02d")
+        self.assertEqual(sensor3.name, "Sensor03")
 
 
-    def testGetItem(self):
-        """ Test for the __getitem__ method. """
-        self.sensor1.channels = {'a': 2, 'b': 3, 'e': 4, 'test': 5}
-        for x in self.sensor1.channels:
-            self.assertEqual(self.sensor1[x], self.sensor1.channels[x])
-
-
-    def testChildren(self):
-        """ Test the children property. """
-        self.sensor1.channels = {1: "1"}
-        self.assertEqual(self.sensor1.children, ["1"])
-        self.assertEqual(self.sensor2.children, [])
-
-
+    @unittest.skip('Test not properly implemented; needs to be rewritten.')
     def testBandwidthCutoff(self):
         """ Test the bandwidthCutoff property. """
         self.sensor1._bandwidthCutoff = 5
@@ -654,6 +634,7 @@ class TestSensor(unittest.TestCase):
         self.assertEqual(self.sensor2.bandwidthCutoff, (1, 2))
 
 
+    @unittest.skip('Test not properly implemented; needs to be rewritten.')
     def testBandwidthRolloff(self):
         """ Test the bandwidthRolloff property. """
         self.sensor1._bandwidthRolloff = 5
@@ -943,7 +924,6 @@ class TestSubChannel:
         assert subChannel1.name == "channel2:00"
         assert subChannel1.units == ('a', 'b')
         assert subChannel1.displayName == 'a'
-        assert subChannel1.sensor == channel1.sensor
         assert subChannel1.types == (channel1.types[0], )
         assert subChannel1.displayRange == [4]
         assert subChannel1.hasDisplayRange is True

--- a/testing/test_import.py
+++ b/testing/test_import.py
@@ -130,3 +130,22 @@ class TestImportRange:
             "Imported file did not contain data for specified channel"
         assert len(doc.channels[32].getSession()) == 0, \
             "Imported file contains data from excluded channel"
+
+
+def test_fingerprint():
+    """ Test that fingerprints are generated correctly when a Dataset is
+        opened, and aren't affected by additional file reads.
+    """
+    doc1 = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+    doc2 = importer.openFile(makeStreamLike("./testing/SSX70065.IDE"))
+
+    fingerprint1 = doc1.fingerprint
+    fingerprint2 = doc2.fingerprint
+
+    assert fingerprint1 is not None
+    assert fingerprint2 is not None
+    assert fingerprint1 != fingerprint2
+
+    doc3 = importer.openFile(makeStreamLike("./testing/SSX66115.IDE"))
+    importer.readData(doc3)
+    assert doc3.fingerprint == fingerprint1


### PR DESCRIPTION
This commit adds the changes made in the `feature/DCB-110_timestamp_offset` that are not specifically related to the sync functionality.

* Added `Sensor` attributes for time sync source info, and `Sensor.getReferrers()` for getting all channel data using that sensor.
* New `Session.__repr__()`
* Added `Dataset.fingerprint`, a hash of the IDE header, for easy identification of recordings regardless of filename (case-sensitive FS, copied files, etc.)

Lesser changes:
* Type annotation added in places where work was done (full annotation should be done in another PR)
* Sphinx documentation updates
* Fixed some tests, disabled some dubious ones.
  * Some are brittle, using components in unrealistic ways; a couple were written to suit the old output, which was wrong, so fixing the problem made them fail.
* Removed old workaround for dictionaries in Python < 3.7
* Improved logger acquisition (the recommended pattern we use in other packages)
* Misc. cleanup, minor reorganization, and trivial fixes.