### PR TITLE
Fix reading files when only the first block has 1 sample

### DIFF
--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -1637,7 +1637,7 @@ class EventArray(Transformable):
             # HACK (somewhat): Single-sample-per-block channels get min/mean/max
             # which is just the same as the value of the sample. Set the values,
             # but don't set hasMinMeanMax.
-            if self._singleSample is True:  # and not self.hasMinMeanMax:
+            if self._singleSample is True & block.numSamples == 1:  # and not self.hasMinMeanMax:
                 block.minMeanMax = np.tile(block.payload, 3)
                 mmmArr = np_recfunctions.structured_to_unstructured(
                         block._minMeanMax.view(self._npType))

--- a/idelib/dataset.py
+++ b/idelib/dataset.py
@@ -1637,7 +1637,7 @@ class EventArray(Transformable):
             # HACK (somewhat): Single-sample-per-block channels get min/mean/max
             # which is just the same as the value of the sample. Set the values,
             # but don't set hasMinMeanMax.
-            if self._singleSample is True & block.numSamples == 1:  # and not self.hasMinMeanMax:
+            if self._singleSample is True and block.numSamples == 1:  # and not self.hasMinMeanMax:
                 block.minMeanMax = np.tile(block.payload, 3)
                 mmmArr = np_recfunctions.structured_to_unstructured(
                         block._minMeanMax.view(self._npType))


### PR DESCRIPTION
Add block.numSamples = 1 condition when setting block.minMeanMax with _singleSample EventArray.

Addresses #123.

428 tests passed, 10 skipped.