### PR TITLE
Feature/hdsp 983 escape control characters

### DIFF
--- a/idelib/schemata/mide_ide.xml
+++ b/idelib/schemata/mide_ide.xml
@@ -97,7 +97,9 @@
             <UIntegerElement name="WispiApiLevel" id="0x4D71" multiple="0" minver="1">WiSpi API Level for network co-processor</UIntegerElement>
             <StringElement name="NcpAppFwVer" id="0x4D72" multiple="0" minver="1">Network Co-Processor Application Firmware Version</StringElement>
             <UIntegerElement name="KeyRev" id="0x5231" multiple="0" minver="1">Indicates the version of the key table, 0 if not present</UIntegerElement>
-            <MasterElement name="SerialCommandInterface" id="0x5230" multiple="0" minver="2" mandatory="0">Present in the device's DEVINFO if it supports control via serial</MasterElement>
+            <MasterElement name="SerialCommandInterface" id="0x5230" multiple="0" minver="2" mandatory="0">Present in the device's DEVINFO if it supports control via serial
+                <BinaryElement name="EscapedCharacters" id="0x5234" multiple="0" mandatory="0">Bytes to be escaped during command packet encoding (in addition to the standard HDLC break and HDLC escape characters)</BinaryElement>
+            </MasterElement>
             <UIntegerElement name="FileCommandInterface" id="0x5233" multiple="0" minver="2" mandatory="0">Element in the device's DEVINFO indicating it supports control via the COMMAND and RESPONSE files. 0 is unsupported, 1 is supported; assumed to be 1 if not present.</UIntegerElement>
         </MasterElement>
         <!-- SensorList and PlotList are optional; there are defaults that will be used. The use of defaults is all-or-nothing; the file should define all sensors or have no SensorList at all. -->

--- a/testing/test_dataset.py
+++ b/testing/test_dataset.py
@@ -34,7 +34,7 @@ from idelib.transforms import AccelTransform, Univariate
 from idelib import importer
 from idelib import parsers
 
-from testing.utils import nullcontext
+from contextlib import nullcontext
 
 from .file_streams import makeStreamLike
 
@@ -1711,7 +1711,7 @@ class TestEventArray:
             expected = np.zeros([4])
             expected[0] = at
             for i in range(1, 4):
-                expected[i] = np.interp([at], vals[0], vals[i])
+                expected[i] = np.interp([at], vals[0], vals[i])[0]
         else:
             expected = None
 

--- a/testing/test_matfile.py
+++ b/testing/test_matfile.py
@@ -32,7 +32,7 @@ from idelib import importer
 from idelib import parsers
 from idelib import matfile
 
-from testing.utils import nullcontext
+from contextlib import nullcontext
 
 from .file_streams import makeStreamLike
 

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -1,9 +1,0 @@
-class nullcontext:
-    """ A replacement for `contextlib.nullcontext` for python versions before 3.7
-    """
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass


### PR DESCRIPTION
* Adds the element `<EscapedCharacters>` to the `mide_ide` schema. For use in special-case device DEVINFO.
* Minor test fix for newer versions on Numpy.