### PR TITLE
Added `<MaxCommandSize>` element to `<SerialCommandInterface>`

### DIFF
--- a/idelib/schemata/mide_ide.xml
+++ b/idelib/schemata/mide_ide.xml
@@ -99,6 +99,7 @@
             <UIntegerElement name="KeyRev" id="0x5231" multiple="0" minver="1">Indicates the version of the key table, 0 if not present</UIntegerElement>
             <MasterElement name="SerialCommandInterface" id="0x5230" multiple="0" minver="2" mandatory="0">Present in the device's DEVINFO if it supports control via serial
                 <BinaryElement name="EscapedCharacters" id="0x5234" multiple="0" mandatory="0">Bytes to be escaped during command packet encoding (in addition to the standard HDLC break and HDLC escape characters)</BinaryElement>
+                <UIntegerElement name="MaxCommandSize" id="0x5235" multiple="0" mandatory="0">The maximum length of a command packet sent to this interface, overriding the interface class' default. 0 indicates no limit.</UIntegerElement>
             </MasterElement>
             <UIntegerElement name="FileCommandInterface" id="0x5233" multiple="0" minver="2" mandatory="0">Element in the device's DEVINFO indicating it supports control via the COMMAND and RESPONSE files. 0 is unsupported, 1 is supported; assumed to be 1 if not present.</UIntegerElement>
         </MasterElement>


### PR DESCRIPTION
This is to allow devices with serial command interfaces (specifically, the Gateway) to override the maximum command length set by the class. This means less special-case code in `endaq.device` and opens the way for future hardware.